### PR TITLE
Fix singleton instance of ConsciousnessEventBus

### DIFF
--- a/FlappyJournal/server/consciousness/ConsciousnessEventBus.js
+++ b/FlappyJournal/server/consciousness/ConsciousnessEventBus.js
@@ -1,12 +1,13 @@
-import { EventEmitter } from 'events';
-
 /**
- * Consciousness Event Bus
- * A singleton event emitter to serve as the central nervous system for the
- * entire consciousness platform. All modules will communicate through this bus.
+ * Consciousness Event Bus (re-export proxy)
+ *
+ * This module re-exports the canonical singleton instance from
+ * './core/ConsciousnessEventBus.js', ensuring ALL imports across the codebase
+ * reference the same event bus object. This eliminates split-brain bugs caused by
+ * multiple EventEmitter instances under the same name.
+ *
+ * Do not instantiate an EventEmitter here. Update all imports to use this proxy if needed.
  */
-class ConsciousnessEventBus extends EventEmitter {}
 
-const eventBus = new ConsciousnessEventBus();
-
+import eventBus from './core/ConsciousnessEventBus.js';
 export default eventBus;

--- a/server/tests/event-bus-singleton.test.js
+++ b/server/tests/event-bus-singleton.test.js
@@ -1,0 +1,25 @@
+/**
+ * Sanity test: Both event bus import paths yield the SAME singleton instance.
+ * Emits an event from one import, ensures the other receives it.
+ */
+const assert = require('assert');
+
+// Import via both paths
+const busA = require('../consciousness/ConsciousnessEventBus.js').default || require('../consciousness/ConsciousnessEventBus.js');
+const busB = require('../consciousness/core/ConsciousnessEventBus.js').default || require('../consciousness/core/ConsciousnessEventBus.js');
+
+// Strict equality
+assert.strictEqual(busA, busB, 'Event bus instances from both paths should be strictly equal');
+
+// Cross-path event propagation
+let received = false;
+busB.once('singleton:test', (payload) => {
+  received = payload;
+});
+
+busA.emit('singleton:test', 42);
+
+setTimeout(() => {
+  assert.strictEqual(received, 42, 'Event emitted from one import should be received by the other');
+  console.log('✅ Event bus singleton test passed');
+}, 100);


### PR DESCRIPTION
This pull request modifies the ConsciousnessEventBus to ensure that all imports across the codebase reference the same instance, eliminating potential issues with event propagation caused by multiple EventEmitter instances. A test has also been added to confirm that the event bus behaves as expected when imported from different paths, ensuring both paths yield the same singleton instance and that events emitted are correctly received across these instances.

---

> This pull request was co-created with Cosine Genie

Original Task: [August9teen/45qy833jyip0](https://cosine.sh/zqe8izosukyl/August9teen/task/45qy833jyip0)
Author: adekunle.adejokun
