### PR TITLE
docs: add self-coding API and deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ docker compose up --build
 docker compose --profile monitoring up --build
 ```
 
+## 📚 Additional Documentation
+
+- [Self-Coding API](docs/self-coding-API.md)
+- [Deployment Guide](docs/deployment-guide.md)
+
 ## 🧬 License
 
 MIT for open-source logic components. Proprietary assets like Flappy IP and the plush toy designs are developed and held under the August9teen creative studio.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,0 +1,43 @@
+# Deployment Guide
+
+## Docker Compose
+
+1. Copy and edit the example environment file.
+   ```bash
+   cp .env.docker.example .env.docker
+   ```
+2. Build and start the stack.
+   ```bash
+   docker compose up --build
+   ```
+3. Include monitoring services when needed.
+   ```bash
+   docker compose --profile monitoring up --build
+   ```
+4. Access services:
+   - API: `http://localhost:<api-port>`
+   - Metrics: `http://localhost:<metrics-port>/metrics`
+
+## Kubernetes
+
+1. Build and push the container image.
+   ```bash
+   docker build -t <registry>/featherweight .
+   docker push <registry>/featherweight
+   ```
+2. Apply manifests from the `k8s/` directory.
+   ```bash
+   kubectl apply -f k8s/
+   ```
+3. Verify that pods are running.
+   ```bash
+   kubectl get pods
+   ```
+4. Expose the service or configure ingress as needed.
+   ```bash
+   kubectl port-forward svc/featherweight 8080:80
+   ```
+5. Scale the deployment.
+   ```bash
+   kubectl scale deployment featherweight --replicas=3
+   ```

--- a/docs/self-coding-API.md
+++ b/docs/self-coding-API.md
@@ -1,0 +1,86 @@
+# Self-Coding API
+
+## Events
+
+### `code:analyze`
+- Initiates static analysis on a module.
+- **Payload**
+  ```json
+  {
+    "moduleId": "string",
+    "code": "string",
+    "options": {}
+  }
+  ```
+
+### `code:analysis:complete`
+- Emitted after analysis finishes.
+- **Payload**
+  ```json
+  {
+    "moduleId": "string",
+    "analysis": {}
+  }
+  ```
+
+### `code:analysis:error`
+- Emitted when analysis fails.
+- **Payload**
+  ```json
+  {
+    "moduleId": "string",
+    "error": "string"
+  }
+  ```
+
+### `code:optimize`
+- Requests performance or style optimizations.
+- **Payload**
+  ```json
+  {
+    "moduleId": "string",
+    "code": "string",
+    "constraints": {}
+  }
+  ```
+
+### `code:optimization:complete`
+- Emitted after optimization completes.
+- **Payload**
+  ```json
+  {
+    "moduleId": "string",
+    "optimization": {}
+  }
+  ```
+
+### `code:generate`
+- Creates a new module from requirements.
+- **Payload**
+  ```json
+  {
+    "moduleId": "string",
+    "requirements": "string"
+  }
+  ```
+
+### `system_tick`
+- Triggers periodic analysis when capacity is available.
+
+### `consciousness:state_change`
+- Updates self-coding behavior based on global system state.
+
+### `consciousness:goal_created`
+- Adds new goals to the planning queue.
+
+### `spiral_memory:pattern_detected`
+- Prioritizes modules based on observed memory patterns.
+
+## Module Responsibilities
+
+- **CodeAnalyzer** – parses source and produces pattern and metric data.
+- **SelfCodingModule** – orchestrates analysis, optimization, and generation and registers all events.
+- **AutonomousCodeRefactoringSystem** – performs background refactors during `system_tick`.
+- **SigilBasedCodeAuthenticator** – validates generated code signatures.
+- **GeminiAIClient/LLM adapter** – provides model-powered generation and refactoring.
+


### PR DESCRIPTION
## Summary
- document self-coding events, payloads and module responsibilities
- add deployment guide covering Docker Compose and Kubernetes
- link new docs from README

## Testing
- `npm test` *(fails: Cannot find module 'semver')*


------
https://chatgpt.com/codex/tasks/task_e_6892bed9eeb08324b5ee510b80d19e40