### PR TITLE
chore: configure code owners and freeze backups

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+FlappyJournal/
+FlappyJournal hey/
+**/*.bak
+**/*.backup
+**/*.orig

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owners
+* @project-maintainers
+
+# Per-folder ownership
+/server/ @backend-team
+/client/ @frontend-team
+/docs/ @docs-team

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+*.orig

--- a/docs/production-readiness/plan.md
+++ b/docs/production-readiness/plan.md
@@ -1,0 +1,18 @@
+# Production Readiness Kick-off
+
+## Meeting Notes
+- Reviewed upcoming feature branches:
+  - `feat/persistence-wal`
+  - `feat/event-broker`
+  - `feat/security-acl`
+  - `feat/observability`
+  - `feat/chaos-dr`
+  - `feat/sigil-sha256`
+- Confirmed need for per-folder CODEOWNERS to streamline reviews.
+- Highlighted existing backup and `.orig` files; these are now ignored by linting to preserve history.
+- Established action item to track production readiness tasks in this document.
+
+## Next Steps
+1. Define owners for each feature branch.
+2. Draft detailed design docs for persistence and event broker.
+3. Schedule security review focused on ACL changes.


### PR DESCRIPTION
## Summary
- ignore backup and `.orig` artifacts from lint
- add per-folder CODEOWNERS with placeholders
- record production readiness kick-off notes

## Testing
- `npm run lint` *(fails: use 'import' instead of 'require')*
- `npm test` *(fails: Cannot find module 'semver/semver.js')*


------
https://chatgpt.com/codex/tasks/task_e_6892c29e42f48324beeb593aa6363f20