### PR TITLE
feat: add postgres audit log

### DIFF
--- a/migrations/add_audit_log.sql
+++ b/migrations/add_audit_log.sql
@@ -1,0 +1,27 @@
+-- Create audit_log parent table with pg_partman managed monthly partitions
+CREATE SCHEMA IF NOT EXISTS postgres;
+CREATE EXTENSION IF NOT EXISTS pg_partman;
+
+CREATE TABLE IF NOT EXISTS postgres.audit_log (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    actor TEXT,
+    action TEXT NOT NULL,
+    details JSONB
+) PARTITION BY RANGE (created_at);
+
+-- Configure pg_partman for monthly partitions
+SELECT partman.create_parent('postgres.audit_log', 'created_at', 'native', 'monthly');
+
+-- Prevent updates or deletes on audit_log
+CREATE OR REPLACE FUNCTION postgres.audit_log_immutable()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_log is immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_log_immutable
+    BEFORE UPDATE OR DELETE ON postgres.audit_log
+    FOR EACH ROW EXECUTE FUNCTION postgres.audit_log_immutable();
+

--- a/server/common/logger.cjs
+++ b/server/common/logger.cjs
@@ -1,6 +1,7 @@
 // Logger setup using pino and config (CommonJS)
 const pino = require('pino');
 const config = require('./config.cjs');
+const { Pool } = require('pg');
 
 const logger = pino({
   level: config.LOG_LEVEL || 'info',
@@ -11,5 +12,27 @@ const logger = pino({
       }
     : undefined,
 });
+
+let pool;
+if (process.env.DATABASE_URL) {
+  pool = new Pool({ connectionString: process.env.DATABASE_URL });
+}
+
+async function writeAuditLog({ actor, action, details }) {
+  if (!pool) return;
+  try {
+    await pool.query(
+      'INSERT INTO postgres.audit_log (actor, action, details) VALUES ($1, $2, $3)',
+      [actor || null, action, details ? JSON.stringify(details) : null]
+    );
+  } catch (err) {
+    logger.error({ err }, 'failed to write audit log');
+  }
+}
+
+logger.audit = async function (action, { actor, details } = {}) {
+  logger.info({ actor, details }, action);
+  await writeAuditLog({ actor, action, details });
+};
 
 module.exports = logger;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,6 +1,16 @@
-import { pgTable, text, serial, integer, boolean, timestamp, json, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, boolean, timestamp, json, jsonb, pgSchema } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
+
+// Audit log table
+const postgres = pgSchema("postgres");
+export const auditLogs = postgres.table("audit_log", {
+  id: serial("id").primaryKey(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  actor: text("actor"),
+  action: text("action").notNull(),
+  details: jsonb("details"),
+});
 
 // Conversations table
 export const conversations = pgTable("conversations", {
@@ -281,6 +291,8 @@ export type BillingTransaction = typeof billingTransactions.$inferSelect;
 export type ConversationMemory = typeof conversationMemories.$inferSelect;
 export type Conversation = typeof conversations.$inferSelect;
 export type EmailQueueItem = typeof emailQueue.$inferSelect;
+export type AuditLog = typeof auditLogs.$inferSelect;
+export type InsertAuditLog = typeof auditLogs.$inferInsert;
 export type InsertJournalEntry = z.infer<typeof insertJournalEntrySchema>;
 export type InsertEmail = z.infer<typeof insertEmailSchema>;
 export type InsertSmsMessage = z.infer<typeof insertSmsMessageSchema>;


### PR DESCRIPTION
## Summary
- add pg_partman-managed `postgres.audit_log` with immutability trigger
- expose audit log table in shared schema
- persist audit events through existing logger

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*


------
https://chatgpt.com/codex/tasks/task_e_6892c2c280248324906a1e60c6e51a76