### PR TITLE
feat: add user deletion pipeline

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,12 @@
 - Returns: Prometheus metrics (text/plain)
 - Requires auth
 
+## `DELETE /v1/user/:uid`
+- Marks the specified user for asynchronous erasure
+- Returns: `{ "status": "pending erase" }`
+- Idempotent: repeating the request yields the same response
+- Actual data removal is handled by a background worker
+
 ---
 
 See OpenAPI spec at `/docs` in a running cluster for full details.

--- a/migrations/add_pending_erase_to_users.sql
+++ b/migrations/add_pending_erase_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS pending_erase boolean DEFAULT false NOT NULL;

--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -90,3 +90,17 @@ paths:
                 properties:
                   error:
                     type: string
+  /v1/user/{uid}:
+    delete:
+      summary: Mark user for erasure
+      parameters:
+        - in: path
+          name: uid
+          schema:
+            type: integer
+          required: true
+      responses:
+        '202':
+          description: User marked for deletion
+        '404':
+          description: User not found

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -363,7 +363,21 @@ export class DatabaseStorage implements IStorage {
       throw error;
     }
   }
-  
+
+  async markUserPendingErase(userId: number): Promise<User | undefined> {
+    try {
+      const [user] = await db
+        .update(users)
+        .set({ pendingErase: true, updatedAt: new Date() })
+        .where(eq(users.id, userId))
+        .returning();
+      return user;
+    } catch (error) {
+      console.error('Error marking user pending erase:', error);
+      return undefined;
+    }
+  }
+
   // Payment Methods
   async getPaymentMethods(userId: number): Promise<PaymentMethod[]> {
     try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,7 @@ import { addConversationRoutes } from "./add-conversation-routes";
 import { startEmailProcessor } from "./email-processor";
 import { startEmailScheduler } from "./scheduler";
 import { initUnifiedChatWS } from "./unified-chat-ws";
+import { startUserEraseWorker } from "./user-eraser";
 import rateLimit from 'express-rate-limit';
 
 import { Registry, collectDefaultMetrics } from 'prom-client';
@@ -142,6 +143,9 @@ app.use((req, res, next) => {
   
   // Start the scheduler for daily inspiration emails
   startEmailScheduler();
+
+  // Start worker to erase user data
+  startUserEraseWorker();
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -24,7 +24,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/health", (_req: Request, res: Response) => {
     res.json({ status: "ok", timestamp: new Date().toISOString() });
   });
-  
+
+  // Mark user account for deletion
+  app.delete("/v1/user/:uid", async (req: Request, res: Response) => {
+    const uid = Number(req.params.uid);
+    if (Number.isNaN(uid)) {
+      return res.status(400).json({ error: "Invalid user id" });
+    }
+    const user = await storage.getUser(uid);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    if (!user.pendingErase) {
+      await storage.markUserPendingErase(uid);
+    }
+    return res.status(202).json({ status: "pending erase" });
+  });
+
   // Simple webhook test endpoint - publicly accessible for external testing
   app.post("/api/webhook-test", (req: Request, res: Response) => {
     console.log('🔔 WEBHOOK TEST ENDPOINT ACCESSED');

--- a/server/user-eraser.ts
+++ b/server/user-eraser.ts
@@ -1,0 +1,55 @@
+import { pool } from './db';
+import fs from 'fs/promises';
+import path from 'path';
+
+const ERASE_INTERVAL_MS = 60_000; // 1 minute
+
+async function eraseUser(userId: number): Promise<void> {
+  await pool.query('BEGIN');
+  try {
+    const tables = [
+      'journal_entries',
+      'emails',
+      'sms_messages',
+      'payment_methods',
+      'billing_transactions',
+      'conversation_memories'
+    ];
+    for (const table of tables) {
+      await pool.query(`DELETE FROM ${table} WHERE user_id = $1`, [userId]);
+    }
+    await pool.query('DELETE FROM users WHERE id = $1', [userId]);
+    await pool.query('COMMIT');
+  } catch (err) {
+    await pool.query('ROLLBACK');
+    console.error('Failed to erase user', userId, err);
+    return;
+  }
+
+  const dirs = [
+    path.join(process.cwd(), 'uploads', String(userId)),
+    path.join(process.cwd(), 'backups', `user-${userId}`)
+  ];
+  for (const dir of dirs) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function startUserEraseWorker(): void {
+  // Periodically erase users marked as pending. The operation is idempotent;
+  // running multiple times has no effect once a user is removed.
+  setInterval(async () => {
+    try {
+      const result = await pool.query('SELECT id FROM users WHERE pending_erase = TRUE');
+      for (const row of result.rows) {
+        await eraseUser(row.id);
+      }
+    } catch (err) {
+      console.error('User erase worker error', err);
+    }
+  }, ERASE_INTERVAL_MS);
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -36,6 +36,7 @@ export const users = pgTable("users", {
   // Password reset fields
   resetToken: text("reset_token"),
   resetTokenExpires: timestamp("reset_token_expires"),
+  pendingErase: boolean("pending_erase").default(false).notNull(),
 });
 
 // Journal entries table


### PR DESCRIPTION
## Summary
- add pending erase flag to users and document deletion API
- add DELETE /v1/user/:uid and background worker to erase user data
- document idempotent deletion flow in API docs and OpenAPI spec

## Testing
- `npm test` *(fails: Cannot find module '/workspace/August9teen/node_modules/semver/semver.js')*


------
https://chatgpt.com/codex/tasks/task_e_6892c2c248348324a4573fb3b33e3af1