### PR TITLE
feat: add sigil hash utility and backfill script

### DIFF
--- a/scripts/backfill-sigil-legacy-hash.mjs
+++ b/scripts/backfill-sigil-legacy-hash.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { Pool } from 'pg';
+import { calcSigilHash } from '../server/consciousness/utils/sigilHash.cjs';
+
+const DATABASE_URL = process.env.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/postgres';
+
+async function main() {
+  const pool = new Pool({ connectionString: DATABASE_URL });
+  try {
+    const { rows } = await pool.query('SELECT sigil_symbol, auth_hash, record FROM sigil_auth');
+    let updated = 0;
+    for (const row of rows) {
+      const record = row.record || {};
+      if (!record.legacyHash) {
+        const base = record.codeHash || row.auth_hash || JSON.stringify(record);
+        record.legacyHash = calcSigilHash(base);
+        await pool.query('UPDATE sigil_auth SET record = $1 WHERE sigil_symbol = $2 AND auth_hash = $3', [record, row.sigil_symbol, row.auth_hash]);
+        updated++;
+      }
+    }
+    console.log(`Updated ${updated} sigil_auth records with legacyHash`);
+  } finally {
+    await pool.end();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(err => {
+    console.error('Error updating legacyHash', err);
+    process.exit(1);
+  });
+}
+

--- a/server/consciousness/__tests__/calcSigilHash.test.cjs
+++ b/server/consciousness/__tests__/calcSigilHash.test.cjs
@@ -1,0 +1,9 @@
+import crypto from 'node:crypto';
+import { calcSigilHash } from '../utils/sigilHash.cjs';
+
+test('calcSigilHash uses sha256 and returns first 12 hex chars', () => {
+  const content = 'hello world';
+  const expected = crypto.createHash('sha256').update(content).digest('hex').slice(0, 12);
+  expect(calcSigilHash(content)).toBe(expected);
+});
+

--- a/server/consciousness/utils/sigilHash.cjs
+++ b/server/consciousness/utils/sigilHash.cjs
@@ -1,0 +1,6 @@
+import crypto from 'node:crypto';
+
+export function calcSigilHash(content) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 12);
+}
+


### PR DESCRIPTION
## Summary
- add `calcSigilHash` utility for SHA256-based sigil hashing
- script to backfill `sigil_auth` records with `legacyHash`
- test coverage for new hash helper

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*
- `node scripts/backfill-sigil-legacy-hash.mjs` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6892c2ac28f0832499583023ca311f7d