### PR TITLE
feat: persist spiral memory to postgres

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "openai": "^4.47.0",
         "opossum": "^9.0.0",
         "pg": "^8.16.3",
+        "pg-cursor": "^2.15.3",
         "prettier": "^3.3.1",
         "prisma": "^5.15.0",
         "prom-client": "^15.1.2",
@@ -12469,6 +12470,15 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
       "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
       "license": "MIT"
+    },
+    "node_modules/pg-cursor": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.15.3.tgz",
+      "integrity": "sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "openai": "^4.47.0",
     "opossum": "^9.0.0",
     "pg": "^8.16.3",
+    "pg-cursor": "^2.15.3",
     "prettier": "^3.3.1",
     "prisma": "^5.15.0",
     "prom-client": "^15.1.2",


### PR DESCRIPTION
## Summary
- inject PostgresStore into SpiralMemoryArchitecture for persistence
- hydrate spiral memory map from Postgres via cursor on startup
- persist stored memories to Postgres and add pg-cursor dependency

## Testing
- `npm run e2e:test-spiral-persistence` *(fails: Missing script "e2e:test-spiral-persistence")*
- `npm test` *(fails: multiple test failures; SyntaxError in adapterContract.spec.ts, missing modules, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6892c2a43940832482511812f85ef183