### PR TITLE
feat: add NATS broker bus

### DIFF
--- a/shared-consciousness/main-server/consciousness/BrokerBus.cjs
+++ b/shared-consciousness/main-server/consciousness/BrokerBus.cjs
@@ -1,0 +1,64 @@
+import { connect, StringCodec } from 'nats';
+
+class BrokerBus {
+    constructor() {
+        this.sc = StringCodec();
+        this.ncPromise = null;
+        this.subscriptions = new Map();
+    }
+
+    async connect() {
+        if (!this.ncPromise) {
+            const servers = process.env.NATS_URL || 'nats://localhost:4222';
+            this.ncPromise = connect({ servers });
+        }
+        return this.ncPromise;
+    }
+
+    async publish(subject, payload) {
+        try {
+            const nc = await this.connect();
+            const data = this.sc.encode(JSON.stringify(payload));
+            nc.publish(subject, data);
+        } catch (err) {
+            console.error('BrokerBus publish error', err);
+        }
+    }
+
+    async subscribe(subject, handler) {
+        const nc = await this.connect();
+        const sub = nc.subscribe(subject);
+        (async () => {
+            for await (const msg of sub) {
+                try {
+                    const decoded = JSON.parse(this.sc.decode(msg.data));
+                    await handler(decoded);
+                } catch (err) {
+                    console.error('BrokerBus subscribe handler error', err);
+                }
+            }
+        })();
+        this.subscriptions.set(subject, sub);
+        return sub;
+    }
+
+    async unsubscribe(subject) {
+        const sub = this.subscriptions.get(subject);
+        if (sub) {
+            sub.unsubscribe();
+            this.subscriptions.delete(subject);
+        }
+    }
+
+    async close() {
+        if (this.ncPromise) {
+            const nc = await this.ncPromise;
+            await nc.close();
+            this.ncPromise = null;
+            this.subscriptions.clear();
+        }
+    }
+}
+
+const brokerBus = new BrokerBus();
+export default brokerBus;


### PR DESCRIPTION
## Summary
- implement NATS-based BrokerBus for pub/sub messaging
- route PriorityEventBus through broker when `BROKER_MODE` is `nats`

## Testing
- `npm test` *(fails: Cannot find module './plugins/ConvertAnsi')*

------
https://chatgpt.com/codex/tasks/task_e_6892c2a3cd80832485b672d8ace67088