### PR TITLE
feat: add memory placement worker

### DIFF
--- a/server/api/routes/index.cjs
+++ b/server/api/routes/index.cjs
@@ -1,5 +1,7 @@
 const express = require('express');
 const realities = require('./realities.cjs');
+const memory = require('./memory.cjs');
 const router = express.Router();
 router.use('/realities', realities);
+router.use('/memory', memory);
 module.exports = router;

--- a/server/api/routes/memory.cjs
+++ b/server/api/routes/memory.cjs
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const { generateId } = require('../../common/id.cjs');
+const eventBusPkg = require('../../consciousness/ConsciousnessEventBus.cjs');
+const eventBus = eventBusPkg.default || eventBusPkg;
+
+router.post('/', (req, res) => {
+  const opId = generateId();
+  eventBus.emit('memory.store', { opId, ...req.body });
+  res.status(202).json({ opId });
+});
+
+module.exports = router;

--- a/server/consciousness/instance.cjs
+++ b/server/consciousness/instance.cjs
@@ -1,6 +1,7 @@
 import { HolographicConsciousnessRealityGenerator } from './holographic-consciousness-reality-generator.cjs';
 import './eventHandlers/realityQueueProducer.cjs';
 import './metricsServer.cjs';
+import './workers/placement.js';
 
 const generator = new HolographicConsciousnessRealityGenerator();
 export default generator;

--- a/server/consciousness/workers/placement.js
+++ b/server/consciousness/workers/placement.js
@@ -1,0 +1,20 @@
+import eventBus from '../ConsciousnessEventBus.cjs';
+
+function calculateSpiralScore(memory) {
+  const content = typeof memory.content === 'string' ? memory.content : '';
+  const depth = typeof memory.depth === 'number' ? memory.depth : 0;
+  const lengthScore = Math.min(1, content.length / 1000);
+  const depthScore = Math.min(1, depth / 10);
+  return Number((0.7 * lengthScore + 0.3 * depthScore).toFixed(3));
+}
+
+eventBus.on('memory.store', (payload = {}) => {
+  const score = calculateSpiralScore(payload);
+  eventBus.emit('memory.stored', {
+    ...payload,
+    score,
+    timestamp: Date.now(),
+  });
+});
+
+export { calculateSpiralScore };


### PR DESCRIPTION
## Summary
- add memory placement worker that scores memories and publishes `memory.stored`
- expose `/memory` endpoint returning `202` with operation id
- register placement worker during consciousness initialization

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*
- `k6 run --vus 1000 --duration 10s scripts/k6-load.cjs` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6892c2a39eb48324979ef24aa673657e