### PR TITLE
Align refactoring threshold property names

### DIFF
--- a/FlappyJournal hey/mechanismdocs/Execute/zen3.md
+++ b/FlappyJournal hey/mechanismdocs/Execute/zen3.md
@@ -476,7 +476,7 @@ class AutonomousCodeRefactoringSystem {
     const { analysis } = analysisResult;
     
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
     

--- a/FlappyJournal/mechanismdocs/Execute/zen3.md
+++ b/FlappyJournal/mechanismdocs/Execute/zen3.md
@@ -476,7 +476,7 @@ class AutonomousCodeRefactoringSystem {
     const { analysis } = analysisResult;
     
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
     

--- a/FlappyJournal/server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
+++ b/FlappyJournal/server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
@@ -149,7 +149,7 @@ class AutonomousCodeRefactoringSystem extends EventEmitter {
     const { analysis } = analysisResult;
 
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
 

--- a/shared-consciousness/main-server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
+++ b/shared-consciousness/main-server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
@@ -137,7 +137,7 @@ export default class AutonomousCodeRefactoringSystem extends EventEmitter {
     const { analysis } = analysisResult;
 
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
 


### PR DESCRIPTION
## Summary
- Fix `needsRefactoring` to compare cyclomatic complexity against `refactoringThresholds.cyclomaticComplexity`
- Update shared module and mechanism docs to reference correct threshold key

## Testing
- `npm test` *(fails: Cannot find module 'semver')*


------
https://chatgpt.com/codex/tasks/task_e_6892c46005008324950fdafe65ffa3b5