### PR TITLE
feat: add backpressure and latency safeguards

### DIFF
--- a/grafana/alert-config.json
+++ b/grafana/alert-config.json
@@ -1,0 +1,18 @@
+{
+  "alerts": [
+    {
+      "name": "FacadeBackpressure",
+      "expr": "jetstream_pending > 10000 or heap_usage_ratio > 0.8",
+      "for": "1m",
+      "labels": { "severity": "warning" },
+      "annotations": { "summary": "Facade overloaded" }
+    },
+    {
+      "name": "EncodeLatencyHigh",
+      "expr": "encode_latency_p95 > 2",
+      "for": "3m",
+      "labels": { "severity": "critical" },
+      "annotations": { "summary": "Encoding latency above 2s for 3m" }
+    }
+  ]
+}

--- a/server/consciousness/dna-sigil-reality-encoding.cjs
+++ b/server/consciousness/dna-sigil-reality-encoding.cjs
@@ -25,12 +25,18 @@ class DNASigilRealityEncoding extends SafeEventEmitter {
         this.evolutionaryHistory = new Map();
         this.healingHistory = new Map();
         this.interactionHistory = new Map();
-        
+        this.encodeLatencySamples = [];
+        this.encodeCircuitOpen = false;
+
         console.log('🧬🔮 DNA-Sigil Reality Encoding System initialized');
     }
-    
+
     async encodeRealityWithDNASigil(reality, encodingParameters = {}) {
+        if (this.encodeCircuitOpen) {
+            throw new Error('Encoding circuit breaker open');
+        }
         console.log(`🧬🔮 Encoding reality ${reality.id} with DNA-Sigil patterns`);
+        const startTime = Date.now();
         
         // Generate consciousness state for encoding
         const encodingConsciousnessState = reality.consciousnessState || {
@@ -107,6 +113,18 @@ class DNASigilRealityEncoding extends SafeEventEmitter {
         await this.store.set(`evo:${encodedReality.id}`,  []);
         await this.store.set(`heal:${encodedReality.id}`, []);
         await this.store.set(`int:${encodedReality.id}`,  []);
+        const duration = Date.now() - startTime;
+        this.encodeLatencySamples.push({ t: Date.now(), v: duration });
+        const windowMs = 3 * 60 * 1000;
+        const now = Date.now();
+        this.encodeLatencySamples = this.encodeLatencySamples.filter(s => now - s.t <= windowMs);
+        const values = this.encodeLatencySamples.map(s => s.v).sort((a,b) => a - b);
+        const idx = Math.floor(values.length * 0.95);
+        const p95 = values[idx] || 0;
+        if (p95 > 2000) {
+            this.encodeCircuitOpen = true;
+            setTimeout(() => { this.encodeCircuitOpen = false; }, windowMs);
+        }
 
         return encodedReality;
     }


### PR DESCRIPTION
## Summary
- guard facade with 429 when JetStream backlog or heap usage is high
- track encode latency and open emergency breaker on sustained slowdown
- add Grafana alert rules for backlog and latency

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6892c2ae92c08324bdaff7d8b496fd16