### PR TITLE
Refactor threshold property to match cyclomatic complexity key

### DIFF
--- a/FlappyJournal hey/mechanismdocs/Execute/zen3.md
+++ b/FlappyJournal hey/mechanismdocs/Execute/zen3.md
@@ -476,7 +476,7 @@ class AutonomousCodeRefactoringSystem {
     const { analysis } = analysisResult;
     
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
     

--- a/FlappyJournal/mechanismdocs/Execute/zen3.md
+++ b/FlappyJournal/mechanismdocs/Execute/zen3.md
@@ -476,7 +476,7 @@ class AutonomousCodeRefactoringSystem {
     const { analysis } = analysisResult;
     
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
     

--- a/FlappyJournal/server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
+++ b/FlappyJournal/server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
@@ -151,7 +151,7 @@ class AutonomousCodeRefactoringSystem extends EventEmitter {
     const { analysis } = analysisResult;
 
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
 

--- a/shared-consciousness/main-server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
+++ b/shared-consciousness/main-server/consciousness/modules/AutonomousCodeRefactoringSystem.cjs
@@ -140,7 +140,7 @@ export default class AutonomousCodeRefactoringSystem extends EventEmitter {
     const { analysis } = analysisResult;
 
     // Check against thresholds
-    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.complexity) {
+    if (analysis.enhanced?.complexityMetrics?.cyclomaticComplexity > this.refactoringThresholds.cyclomaticComplexity) {
       return true;
     }
 


### PR DESCRIPTION
## Summary
- use `refactoringThresholds.cyclomaticComplexity` when checking code analysis results
- keep duplication and nesting depth threshold checks consistent
- update related documentation to reflect the correct key

## Testing
- `npm test` *(fails: Cannot find module '/workspace/August9teen/node_modules/semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6892c6d83d488324a72137597b5509c2