### PR TITLE
Add event bus Prometheus metrics

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -6,3 +6,11 @@ scrape_configs:
     metrics_path: /metrics
     static_configs:
       - targets: ['spiral-app:9099']
+  - job_name: 'api'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api:3000']
+  - job_name: 'core'
+    metrics_path: /
+    static_configs:
+      - targets: ['core:9100']


### PR DESCRIPTION
## Summary
- instrument PriorityEventBus with Prometheus gauge and counter metrics
- expose API and core metrics endpoints to Prometheus scraper

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*
- `npm run lint` *(fails: Cannot read config file: FlappyJournal hey/.eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_6892c2ab9eb08324abdccd767e0bb6a1