### PR TITLE
feat: add reality access log

### DIFF
--- a/migrations/add_reality_access_log.sql
+++ b/migrations/add_reality_access_log.sql
@@ -1,0 +1,22 @@
+-- Create reality_access_log table for tracking scene access
+CREATE SCHEMA IF NOT EXISTS postgres;
+
+CREATE TABLE IF NOT EXISTS postgres.reality_access_log (
+    id BIGSERIAL PRIMARY KEY,
+    scene_id TEXT NOT NULL,
+    user_id INTEGER,
+    accessed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    action TEXT NOT NULL
+);
+
+-- Prevent updates or deletes on reality_access_log
+CREATE OR REPLACE FUNCTION postgres.reality_access_log_immutable()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'reality_access_log is immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER reality_access_log_immutable
+    BEFORE UPDATE OR DELETE ON postgres.reality_access_log
+    FOR EACH ROW EXECUTE FUNCTION postgres.reality_access_log_immutable();

--- a/server/api/routes/realities.cjs
+++ b/server/api/routes/realities.cjs
@@ -2,11 +2,13 @@ const express = require('express');
 const router = express.Router();
 const realityService = require('../services/realityService.cjs');
 const metrics = require('../metrics.cjs');
+const logger = require('../../common/logger.cjs');
 
 router.post('/', async (req, res) => {
   try {
     const reality = await realityService.createReality(req.body);
     metrics.realitiesCreated.inc();
+    await logger.realityAccess(reality.id, 'api_create', { userId: req.body.userId });
     res.status(201).json(reality);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -16,6 +18,9 @@ router.post('/', async (req, res) => {
 router.get('/', async (req, res) => {
   try {
     const realities = await realityService.getAllRealities();
+    for (const r of realities) {
+      await logger.realityAccess(r.id, 'api_read', { userId: req.user?.id });
+    }
     res.json(realities);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/api/services/realityService.cjs
+++ b/server/api/services/realityService.cjs
@@ -11,7 +11,13 @@ module.exports = {
   async encodeReality(reality) {
     return await encoder.encodeRealityWithDNASigil(reality);
   },
+  async createReality(reality) {
+    return await encoder.encodeRealityWithDNASigil(reality);
+  },
   async getEncodedReality(id) {
     return await encoder.getEncodedReality(id);
+  },
+  async getAllRealities() {
+    return Array.from(encoder.encodedRealities.values());
   }
 };

--- a/server/common/logger.cjs
+++ b/server/common/logger.cjs
@@ -35,4 +35,21 @@ logger.audit = async function (action, { actor, details } = {}) {
   await writeAuditLog({ actor, action, details });
 };
 
+async function writeRealityAccessLog({ sceneId, userId, action }) {
+  if (!pool) return;
+  try {
+    await pool.query(
+      'INSERT INTO postgres.reality_access_log (scene_id, user_id, action) VALUES ($1, $2, $3)',
+      [sceneId, userId || null, action]
+    );
+  } catch (err) {
+    logger.error({ err }, 'failed to write reality access log');
+  }
+}
+
+logger.realityAccess = async function (sceneId, action, { userId } = {}) {
+  logger.info({ sceneId, userId }, `reality_access:${action}`);
+  await writeRealityAccessLog({ sceneId, userId, action });
+};
+
 module.exports = logger;

--- a/server/consciousness/dna-sigil-reality-encoding.cjs
+++ b/server/consciousness/dna-sigil-reality-encoding.cjs
@@ -36,6 +36,9 @@ class DNASigilRealityEncoding extends SafeEventEmitter {
             throw new Error('Encoding circuit breaker open');
         }
         console.log(`🧬🔮 Encoding reality ${reality.id} with DNA-Sigil patterns`);
+        if (this.logger && typeof this.logger.realityAccess === 'function') {
+            await this.logger.realityAccess(reality.id, 'encode', { userId: reality.userId });
+        }
         const startTime = Date.now();
         
         // Generate consciousness state for encoding
@@ -829,7 +832,10 @@ class DNASigilRealityEncoding extends SafeEventEmitter {
     }
     
     // Public API methods
-    getEncodedReality(encodedRealityId) {
+    async getEncodedReality(encodedRealityId) {
+        if (this.logger && typeof this.logger.realityAccess === 'function') {
+            await this.logger.realityAccess(encodedRealityId, 'read');
+        }
         return this.encodedRealities.get(encodedRealityId);
     }
     

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -12,6 +12,15 @@ export const auditLogs = postgres.table("audit_log", {
   details: jsonb("details"),
 });
 
+// Reality access log table
+export const realityAccessLogs = postgres.table("reality_access_log", {
+  id: serial("id").primaryKey(),
+  sceneId: text("scene_id").notNull(),
+  userId: integer("user_id"),
+  accessedAt: timestamp("accessed_at").defaultNow().notNull(),
+  action: text("action").notNull(),
+});
+
 // Conversations table
 export const conversations = pgTable("conversations", {
   id: serial("id").primaryKey(),
@@ -294,6 +303,8 @@ export type Conversation = typeof conversations.$inferSelect;
 export type EmailQueueItem = typeof emailQueue.$inferSelect;
 export type AuditLog = typeof auditLogs.$inferSelect;
 export type InsertAuditLog = typeof auditLogs.$inferInsert;
+export type RealityAccessLog = typeof realityAccessLogs.$inferSelect;
+export type InsertRealityAccessLog = typeof realityAccessLogs.$inferInsert;
 export type InsertJournalEntry = z.infer<typeof insertJournalEntrySchema>;
 export type InsertEmail = z.infer<typeof insertEmailSchema>;
 export type InsertSmsMessage = z.infer<typeof insertSmsMessageSchema>;


### PR DESCRIPTION
## Summary
- record reality access events in postgres and shared schema
- log scene interactions from generator and API layers
- expose service helpers to create and list encoded realities

## Testing
- `npm test` *(fails: Cannot find module 'semver')*


------
https://chatgpt.com/codex/tasks/task_e_6892cf3fd6648324b65bd984aea7bbcb