### PR TITLE
Add Litmus chaos experiments and scheduling

### DIFF
--- a/docs/chaos-results/README.md
+++ b/docs/chaos-results/README.md
@@ -1,0 +1,5 @@
+# Chaos Experiment Results
+
+This directory stores the `ChaosResult` outputs captured from each Litmus experiment run. Files are named after the experiment and timestamped, e.g. `holograph-pod-kill-20240101030000.yaml`.
+
+The directory also contains `cron.log` when experiments are scheduled via `scripts/schedule-chaos.sh`.

--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -1,0 +1,33 @@
+# Chaos Testing with Litmus
+
+This project uses [LitmusChaos](https://litmuschaos.io/) to validate resiliency. The manifests for each experiment live in `k8s/chaos/` and can be executed manually or on a schedule.
+
+## Experiments
+
+- **Pod Kill**: Deletes one of the application pods to ensure that the deployment recovers.
+- **DB Loss**: Simulates database unavailability by deleting a database pod.
+- **Broker Partition**: Introduces a network partition for the message broker pods.
+
+## Running Experiments
+
+Ensure you have `kubectl` access to the cluster and Litmus installed. Then run:
+
+```bash
+./scripts/run-chaos-experiments.sh
+```
+
+The script applies each experiment manifest and captures the resulting `ChaosResult` into `docs/chaos-results/` with a timestamped filename.
+
+## Scheduling
+
+To execute the suite nightly at 03:00, install a cron job:
+
+```bash
+./scripts/schedule-chaos.sh
+```
+
+This script adds a crontab entry that runs `run-chaos-experiments.sh` and logs output to the results directory.
+
+## Viewing Results
+
+Each run produces YAML files in `docs/chaos-results/`. Review these files to verify the outcome of the experiments and track failures over time.

--- a/k8s/chaos/broker-partition.yaml
+++ b/k8s/chaos/broker-partition.yaml
@@ -1,0 +1,20 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: holograph-broker-partition
+  namespace: default
+spec:
+  appinfo:
+    appns: default
+    applabel: app=holograph-broker
+    appkind: statefulset
+  chaosServiceAccount: litmus-admin
+  experiments:
+    - name: pod-network-partition
+      spec:
+        components:
+          env:
+            - name: NETWORK_AFFECTED_PERCENT
+              value: '100'
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'

--- a/k8s/chaos/db-loss.yaml
+++ b/k8s/chaos/db-loss.yaml
@@ -1,0 +1,20 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: holograph-db-loss
+  namespace: default
+spec:
+  appinfo:
+    appns: default
+    applabel: app=holograph-db
+    appkind: statefulset
+  chaosServiceAccount: litmus-admin
+  experiments:
+    - name: pod-delete
+      spec:
+        components:
+          env:
+            - name: TOTAL_CHAOS_DURATION
+              value: '30'
+            - name: CHAOS_INTERVAL
+              value: '10'

--- a/k8s/chaos/pod-kill.yaml
+++ b/k8s/chaos/pod-kill.yaml
@@ -1,0 +1,20 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: holograph-pod-kill
+  namespace: default
+spec:
+  appinfo:
+    appns: default
+    applabel: app=holograph-gateway
+    appkind: deployment
+  chaosServiceAccount: litmus-admin
+  experiments:
+    - name: pod-delete
+      spec:
+        components:
+          env:
+            - name: TOTAL_CHAOS_DURATION
+              value: '30'
+            - name: CHAOS_INTERVAL
+              value: '10'

--- a/scripts/run-chaos-experiments.sh
+++ b/scripts/run-chaos-experiments.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHAOS_DIR="$(dirname "$0")/../k8s/chaos"
+RESULTS_DIR="$(dirname "$0")/../docs/chaos-results"
+mkdir -p "$RESULTS_DIR"
+
+run_and_collect() {
+  local manifest="$1"
+  local engine_name="$2"
+
+  kubectl apply -f "$manifest"
+  kubectl wait --for=condition=completed --timeout=600s chaosengine "$engine_name" || true
+  kubectl get chaosresult -l chaosengine="$engine_name" -o yaml > "$RESULTS_DIR/${engine_name}-$(date +%Y%m%d%H%M%S).yaml"
+}
+
+run_and_collect "$CHAOS_DIR/pod-kill.yaml" holograph-pod-kill
+run_and_collect "$CHAOS_DIR/db-loss.yaml" holograph-db-loss
+run_and_collect "$CHAOS_DIR/broker-partition.yaml" holograph-broker-partition

--- a/scripts/schedule-chaos.sh
+++ b/scripts/schedule-chaos.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(dirname "$0")/.."
+CMD="$ROOT_DIR/scripts/run-chaos-experiments.sh"
+LOG_DIR="$ROOT_DIR/docs/chaos-results"
+mkdir -p "$LOG_DIR"
+
+CRON_SCHEDULE="0 3 * * *"
+(
+  crontab -l 2>/dev/null
+  echo "$CRON_SCHEDULE $CMD >> $LOG_DIR/cron.log 2>&1"
+) | crontab -
+
+echo "Chaos experiments scheduled with cron expression '$CRON_SCHEDULE'."
+echo "Results will be stored in $LOG_DIR."


### PR DESCRIPTION
## Summary
- document LitmusChaos setup for pod kill, DB loss and broker partition experiments
- add manifests and scripts to run experiments and schedule them via cron

## Testing
- `npm test` *(fails: Cannot find module 'semver')*


------
https://chatgpt.com/codex/tasks/task_e_6892cf3f91708324964b7b3895d672d7