### PR TITLE
Add holo-generator Helm chart

### DIFF
--- a/charts/holo-generator/.helmignore
+++ b/charts/holo-generator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/holo-generator/Chart.yaml
+++ b/charts/holo-generator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: holo-generator
+description: Helm chart for the holo-generator service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/holo-generator/templates/_helpers.tpl
+++ b/charts/holo-generator/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{- define "holo-generator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "holo-generator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "holo-generator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "holo-generator.labels" -}}
+app.kubernetes.io/name: {{ include "holo-generator.name" . }}
+helm.sh/chart: {{ include "holo-generator.chart" . }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "holo-generator.selectorLabels" -}}
+app: {{ include "holo-generator.name" . }}
+{{- end -}}

--- a/charts/holo-generator/templates/configmap.yaml
+++ b/charts/holo-generator/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "holo-generator.fullname" . }}-config
+data:
+{{- range $key, $value := .Values.env }}
+  {{ $key }}: "{{ $value }}"
+{{- end }}

--- a/charts/holo-generator/templates/deployment.yaml
+++ b/charts/holo-generator/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "holo-generator.fullname" . }}
+  labels:
+    {{- include "holo-generator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "holo-generator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "holo-generator.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "holo-generator.fullname" . }}-config
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/holo-generator/templates/hpa.yaml
+++ b/charts/holo-generator/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "holo-generator.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "holo-generator.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.cpu }}
+    - type: Pods
+      pods:
+        metric:
+          name: jetstream_lag
+        target:
+          type: AverageValue
+          averageValue: "{{ .Values.hpa.jetstreamLag }}"
+{{- end }}

--- a/charts/holo-generator/templates/service.yaml
+++ b/charts/holo-generator/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "holo-generator.fullname" . }}
+  labels:
+    {{- include "holo-generator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "holo-generator.selectorLabels" . | nindent 4 }}

--- a/charts/holo-generator/values.yaml
+++ b/charts/holo-generator/values.yaml
@@ -1,0 +1,27 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/example/holo-generator
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+# Environment variables for the application
+env:
+  NATS_URL: nats://nats:4222
+  LOG_LEVEL: info
+
+# Resources for the container
+resources: {}
+
+# Horizontal Pod Autoscaler settings
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  cpu: 70
+  jetstreamLag: 5000


### PR DESCRIPTION
## Summary
- add Helm chart for holo-generator deployment
- configure env-backed ConfigMap with probes and service
- add HPA scaling on CPU utilization and JetStream lag

## Testing
- `helm lint charts/holo-generator`

------
https://chatgpt.com/codex/tasks/task_e_6892cf3d4e9c8324a9f2678b0555609c