### PR TITLE
docs: expand runbook with onboarding and recovery steps

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -10,10 +10,23 @@
 - **On-call:** @sre-team
 - **PagerDuty:** https://example.pagerduty.com
 
+## Onboarding Steps
+
+1. Request access to the GitHub repository, Kubernetes cluster, and monitoring tools.
+2. Clone the repository and run `npm install` followed by `npm test` to verify the environment.
+3. Review this runbook and related architecture documents.
+4. Deploy to the staging environment using the [Helm chart](https://charts.example.com/holograph).
+5. Familiarize yourself with the Grafana and alert dashboards.
+
 ## Dashboard URLs
 
 - **Grafana:** https://grafana.example.com/d/holograph-baseline/holograph-baseline-metrics
 - **Prometheus:** https://prometheus.example.com
+- **Alert Dashboard:** https://grafana.example.com/d/holograph-alerts/holograph-alerts
+
+## Helm Chart
+
+- https://charts.example.com/holograph
 
 ## Key SLOs and Alert Meanings
 
@@ -21,6 +34,12 @@
 - **RecursiveExplosion**: The scene graph depth has exceeded the safe threshold of 10.
 - **FrameBudgetBreach**: The renderer is frequently exceeding its frame budget.
 - **GPUOOMRisk**: The GPU memory usage is at risk of exceeding its capacity.
+
+## Rollback Procedure
+
+1. Identify the previous stable release using `helm history holograph`.
+2. Roll back using `helm rollback holograph <revision>`.
+3. Monitor the [alert dashboard](https://grafana.example.com/d/holograph-alerts/holograph-alerts) and application logs to confirm recovery.
 
 ## Secret Rotation Procedures
 
@@ -45,3 +64,10 @@
 ### Rehearsal Schedule
 - Conduct a full rotation rehearsal in staging every March and September.
 - Document lessons learned and update this runbook after each rehearsal.
+
+## Disaster Recovery
+
+1. Fetch the latest S3 snapshot of persistent data: `aws s3 cp s3://holograph-backups/latest.tar.gz .`.
+2. Restore the snapshot to the database or storage layer.
+3. Redeploy the stack using the [Helm chart](https://charts.example.com/holograph).
+4. Validate service health on the [alert dashboard](https://grafana.example.com/d/holograph-alerts/holograph-alerts) and Grafana.


### PR DESCRIPTION
## Summary
- add onboarding steps with helm chart and alert dashboard links
- document generic helm rollback procedure
- describe S3 snapshot disaster recovery workflow

## Testing
- `npm test` (fails: Cannot find module 'semver')

------
https://chatgpt.com/codex/tasks/task_e_6892cf3ce0f48324b5f405526f6190a7