### PR TITLE
feat: add scene deletion endpoint

### DIFF
--- a/FlappyJournal/server/sceneDeletionWorker.cjs
+++ b/FlappyJournal/server/sceneDeletionWorker.cjs
@@ -1,0 +1,25 @@
+const { parentPort } = require('worker_threads');
+const pool = require('./db.cjs');
+const { S3Client, DeleteObjectCommand } = require('@aws-sdk/client-s3');
+
+const s3 = new S3Client({});
+const bucket = process.env.SCENE_SNAPSHOT_BUCKET;
+
+parentPort.on('message', async ({ sceneId }) => {
+  try {
+    if (!sceneId) return;
+    // Delete scene nodes from Postgres
+    await pool.query('DELETE FROM "SceneNode" WHERE "sceneId" = $1', [sceneId]);
+
+    // Delete snapshot from S3 if configured
+    if (bucket) {
+      const key = `snapshots/${sceneId}.json`;
+      await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    }
+
+    parentPort.postMessage({ sceneId, success: true });
+  } catch (err) {
+    console.error('Scene cleanup failed:', err);
+    parentPort.postMessage({ sceneId, success: false, error: err.message });
+  }
+});


### PR DESCRIPTION
## Summary
- add worker thread to remove scenes
- expose `DELETE /scene/:id` to queue cleanup

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6892cf3c6d68832490981b4d0c456621