### PR TITLE
Add CI workflow with unit, integration, load and ZAP scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run unit tests
+        run: npm run test:unit
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: unit
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run integration tests
+        run: npm test
+
+  load_smoke:
+    runs-on: ubuntu-latest
+    needs: integration
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Start API
+        run: |
+          npm run start:api &
+          sleep 15
+      - name: Install k6
+        uses: grafana/setup-k6-action@v1
+      - name: Run load smoke tests
+        run: npm run load:test
+
+  zap_scan:
+    runs-on: ubuntu-latest
+    needs: load_smoke
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Start API
+        run: |
+          npm run start:api &
+          sleep 15
+      - name: ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.7.0
+        with:
+          target: 'http://localhost:3000'
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `ci.yml` with unit, integration, load_smoke, and zap_scan jobs
- include Node version matrix for unit tests and sequential dependencies across jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `npm test` *(fails: Error: Cannot find module './plugins/ConvertAnsi')*


------
https://chatgpt.com/codex/tasks/task_e_6892cf394cf88324a434058edb5ed388