### PR TITLE
Add basic Grafana dashboard

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1,0 +1,36 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "Runtime Metrics",
+    "panels": [
+      {
+        "type": "timeseries",
+        "title": "Scene Latency",
+        "targets": [
+          { "expr": "scene_latency_ms" }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "title": "WS FPS",
+        "targets": [
+          { "expr": "ws_fps" }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "title": "Heap Usage",
+        "targets": [
+          { "expr": "heap_usage_ratio" }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "title": "DB Size",
+        "targets": [
+          { "expr": "db_size_bytes" }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add runtime dashboard for scene latency, websocket fps, heap usage, and db size metrics

## Testing
- `npm test` *(fails: Cannot find module 'semver')*

------
https://chatgpt.com/codex/tasks/task_e_6892cf324f1c8324b6bdfa66f3cbf417