### PR TITLE
feat: add prometheus alert rules

### DIFF
--- a/deploy/k8s/prometheus-rules.yaml
+++ b/deploy/k8s/prometheus-rules.yaml
@@ -23,3 +23,29 @@ spec:
           annotations:
             summary: "CRN tick stalled"
             description: "No CRN ticks in last 1m"
+    - name: system.rules
+      rules:
+        - alert: SceneGenLatencyP95High
+          expr: histogram_quantile(0.95, rate(scene_gen_latency_ms_bucket[5m])) > 1000
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Scene generation latency p95 above 1s"
+            description: "p95 of scene_gen_latency_ms exceeded 1s"
+
+        - alert: HeapUsageHigh
+          expr: heap_usage > 0.8
+          labels:
+            severity: warning
+          annotations:
+            summary: "Heap usage above 80%"
+            description: "Heap usage is {{ $value | humanizePercentage }}"
+
+        - alert: JetstreamPendingHigh
+          expr: jetstream_pending > 50000
+          labels:
+            severity: warning
+          annotations:
+            summary: "Jetstream pending messages exceed 50k"
+            description: "Jetstream has {{ $value }} pending messages"

--- a/monitoring/prometheus/alerts.yaml
+++ b/monitoring/prometheus/alerts.yaml
@@ -1,0 +1,27 @@
+groups:
+  - name: system.rules
+    rules:
+      - alert: SceneGenLatencyP95High
+        expr: histogram_quantile(0.95, rate(scene_gen_latency_ms_bucket[5m])) > 1000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Scene generation latency p95 above 1s"
+          description: "p95 of scene_gen_latency_ms exceeded 1s"
+
+      - alert: HeapUsageHigh
+        expr: heap_usage > 0.8
+        labels:
+          severity: warning
+        annotations:
+          summary: "Heap usage above 80%"
+          description: "Heap usage is {{ $value | humanizePercentage }}"
+
+      - alert: JetstreamPendingHigh
+        expr: jetstream_pending > 50000
+        labels:
+          severity: warning
+        annotations:
+          summary: "Jetstream pending messages exceed 50k"
+          description: "Jetstream has {{ $value }} pending messages"


### PR DESCRIPTION
## Summary
- add alert rules for scene gen latency, heap usage, and jetstream backlog
- include new rules in PrometheusRule Helm config

## Testing
- `npm test` (fails: Cannot find module 'semver')


------
https://chatgpt.com/codex/tasks/task_e_6892cf2ff69083248f5785a13bb3db8e