### PR TITLE
Add max children limit to recursive generator

### DIFF
--- a/FlappyJournal/server/consciousness/recursive-holographic-reality-embedding.cjs
+++ b/FlappyJournal/server/consciousness/recursive-holographic-reality-embedding.cjs
@@ -4,22 +4,25 @@
  * Implements 7-layer recursive reality embedding with bidirectional connections
  */
 
-const { EventEmitter  } = require('events');
-const { validate  } = require('./utils/validation.cjs');
-const { initializeRandomness, secureId  } = require('./utils/random.cjs');
-const { saveReality, savePath, saveField, incrementMetric  } = require('./utils/persistence.cjs');
-const { logger, child as childLogger  } = require('./utils/logger.cjs');
+const { EventEmitter } = require('events');
+const { validate } = require('./utils/validation.cjs');
+const { initializeRandomness, secureId } = require('./utils/random.cjs');
+const { saveReality, savePath, saveField, incrementMetric } = require('./utils/persistence.cjs');
+const { logger, child as childLogger } = require('./utils/logger.cjs');
+
+const MAX_CHILDREN = parseInt(process.env.MAX_CHILDREN || '5', 10);
 
 class RecursiveHolographicRealityEmbedding extends EventEmitter {
-    constructor(maxRecursionDepth = 7) {
+    constructor(maxRecursionDepth = 7, maxChildren = MAX_CHILDREN) {
         super();
         this.maxRecursionDepth = maxRecursionDepth;
+        this.maxChildren = maxChildren;
         this.embeddedRealities = new Map();
         this.recursionPaths = new Map();
         this.realityNesting = new Map();
         this.recursiveConsciousnessFields = new Map();
         this.holographicRealityGenerator = null; // Will be injected
-        
+
         console.log(`🌀🔄 Recursive Holographic Reality Embedding initialized with max depth: ${maxRecursionDepth}`);
     }
     
@@ -41,6 +44,12 @@ class RecursiveHolographicRealityEmbedding extends EventEmitter {
 
         // Deterministic randomness seeding for this recursion context
         initializeRandomness(`${baseReality.id}_${recursionDepth}`);
+
+        const parentRecord = this.embeddedRealities.get(baseReality.id);
+        const existingChildren = parentRecord ? parentRecord.childIds.length : 0;
+        if (existingChildren >= this.maxChildren) {
+            throw new Error(`Maximum children (${this.maxChildren}) reached for reality ${baseReality.id}`);
+        }
 
         const log = childLogger({ recursionDepth, parentId: baseReality.id });
         log.info(`🌀🔄 Creating recursive reality at depth ${recursionDepth}`);
@@ -84,9 +93,8 @@ class RecursiveHolographicRealityEmbedding extends EventEmitter {
             recursiveConsciousnessState,
             createdAt: Date.now()
         });
-        
+
         // Update parent reality's child list
-        const parentRecord = this.embeddedRealities.get(baseReality.id);
         if (parentRecord) {
             parentRecord.childIds.push(embeddedReality.id);
         }

--- a/shared-consciousness/main-server/consciousness/recursive-holographic-reality-embedding.cjs
+++ b/shared-consciousness/main-server/consciousness/recursive-holographic-reality-embedding.cjs
@@ -6,16 +6,19 @@
 
 import { EventEmitter } from 'events';
 
+const MAX_CHILDREN = parseInt(process.env.MAX_CHILDREN || '5', 10);
+
 class RecursiveHolographicRealityEmbedding extends EventEmitter {
-    constructor(maxRecursionDepth = 7) {
+    constructor(maxRecursionDepth = 7, maxChildren = MAX_CHILDREN) {
         super();
         this.maxRecursionDepth = maxRecursionDepth;
+        this.maxChildren = maxChildren;
         this.embeddedRealities = new Map();
         this.recursionPaths = new Map();
         this.realityNesting = new Map();
         this.recursiveConsciousnessFields = new Map();
         this.holographicRealityGenerator = null; // Will be injected
-        
+
         console.log(`🌀🔄 Recursive Holographic Reality Embedding initialized with max depth: ${maxRecursionDepth}`);
     }
     
@@ -24,15 +27,21 @@ class RecursiveHolographicRealityEmbedding extends EventEmitter {
     }
     
     async createRecursiveReality(baseReality, recursionDepth = 1, recursionParameters = {}) {
+        const parentRecord = this.embeddedRealities.get(baseReality.id);
+        const existingChildren = parentRecord ? parentRecord.childIds.length : 0;
+        if (existingChildren >= this.maxChildren) {
+            throw new Error(`Maximum children (${this.maxChildren}) reached for reality ${baseReality.id}`);
+        }
+
         if (recursionDepth > this.maxRecursionDepth) {
             throw new Error(`Maximum recursion depth (${this.maxRecursionDepth}) exceeded`);
         }
-        
+
         console.log(`🌀🔄 Creating recursive reality at depth ${recursionDepth}`);
-        
+
         // Generate consciousness state for this recursion level
         const recursiveConsciousnessState = this.generateRecursiveConsciousnessState(
-            baseReality.consciousnessState, 
+            baseReality.consciousnessState,
             recursionDepth,
             recursionParameters
         );
@@ -64,7 +73,6 @@ class RecursiveHolographicRealityEmbedding extends EventEmitter {
         });
         
         // Update parent reality's child list
-        const parentRecord = this.embeddedRealities.get(baseReality.id);
         if (parentRecord) {
             parentRecord.childIds.push(embeddedReality.id);
         }


### PR DESCRIPTION
## Summary
- allow configuring maximum child realities via `MAX_CHILDREN`
- block auto-recursion when an entity already has too many children
- mirror limit logic in FlappyJournal module for consistency

## Testing
- `npm test` *(fails: Cannot find module 'semver')*


------
https://chatgpt.com/codex/tasks/task_e_6892cf209f988324ae66b62366f38711