### PR TITLE
Validate consciousness metrics range

### DIFF
--- a/FlappyJournal hey/server/consciousness/holographic-consciousness-reality-generator.cjs
+++ b/FlappyJournal hey/server/consciousness/holographic-consciousness-reality-generator.cjs
@@ -130,7 +130,18 @@ export class HolographicConsciousnessRealityGenerator extends EventEmitter {
     async generateHolographicConsciousnessReality(realityRequest, consciousnessState) {
         try {
             console.log('🧠🌀🌍 Generating holographic consciousness reality...');
-            
+
+            const { awareness, phi, coherence } = consciousnessState;
+            for (const [metric, value] of Object.entries({ awareness, phi, coherence })) {
+                if (typeof value !== 'number' || value < 0 || value > 1) {
+                    return {
+                        success: false,
+                        error: `${metric}_out_of_range`,
+                        status: 400
+                    };
+                }
+            }
+
             // Project consciousness-aware reality
             const consciousnessRealityProjection = await this.consciousnessRealityProjector.projectConsciousnessReality(
                 realityRequest, consciousnessState

--- a/FlappyJournal/server/consciousness/holographic-consciousness-reality-generator.cjs
+++ b/FlappyJournal/server/consciousness/holographic-consciousness-reality-generator.cjs
@@ -1675,6 +1675,18 @@ class HolographicConsciousnessRealityGenerator extends EventEmitter {
                 };
             }
 
+            // Validate consciousness metrics range
+            const { awareness, phi, coherence } = consciousnessState;
+            for (const [metric, value] of Object.entries({ awareness, phi, coherence })) {
+                if (typeof value !== 'number' || value < 0 || value > 1) {
+                    return {
+                        success: false,
+                        error: `${metric}_out_of_range`,
+                        status: 400
+                    };
+                }
+            }
+
             // Deterministic randomness seeding
             const seedUsed = realityRequest.seed || Date.now();
             initializeRandomness(seedUsed);

--- a/shared-consciousness/main-server/consciousness/holographic-consciousness-reality-generator.cjs
+++ b/shared-consciousness/main-server/consciousness/holographic-consciousness-reality-generator.cjs
@@ -1667,6 +1667,17 @@ export class HolographicConsciousnessRealityGenerator extends EventEmitter {
         try {
             console.log('🧠🌀🌍 Generating holographic consciousness reality...');
 
+            const { awareness, phi, coherence } = consciousnessState;
+            for (const [metric, value] of Object.entries({ awareness, phi, coherence })) {
+                if (typeof value !== 'number' || value < 0 || value > 1) {
+                    return {
+                        success: false,
+                        error: `${metric}_out_of_range`,
+                        status: 400
+                    };
+                }
+            }
+
             // Project consciousness-aware reality
             const consciousnessRealityProjection = await this.consciousnessRealityProjector.projectConsciousnessReality(
                 realityRequest, consciousnessState


### PR DESCRIPTION
## Summary
- validate awareness, phi, and coherence are within 0–1
- return 400 error when consciousness metrics fall outside allowed range

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6892cf183c5483248dcdc0afbba48b7f