### PR TITLE
feat: add workerpool projection worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "sentiment": "^5.0.2",
         "swagger-ui-express": "^5.0.1",
         "three": "^0.165.0",
+        "workerpool": "^9.3.3",
         "yamljs": "^0.3.0"
       },
       "devDependencies": {
@@ -16942,6 +16943,12 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/workerpool": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.3.tgz",
+      "integrity": "sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==",
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "js-yaml": "^4.1.0",
     "jscpd": "^4.0.5",
     "jsonwebtoken": "^8.5.1",
-    "jws": "^4.0.0",
     "jwks-rsa": "^3.1.0",
+    "jws": "^4.0.0",
     "lz4js": "^0.2.0",
     "msgpack5": "^6.0.2",
     "nats": "^2.23.0",
@@ -62,6 +62,7 @@
     "sentiment": "^5.0.2",
     "swagger-ui-express": "^5.0.1",
     "three": "^0.165.0",
+    "workerpool": "^9.3.3",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/server/consciousness/holographic-consciousness-reality-generator.cjs
+++ b/server/consciousness/holographic-consciousness-reality-generator.cjs
@@ -1,0 +1,23 @@
+import workerpool from 'workerpool';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pool = workerpool.pool(join(__dirname, 'workers', 'calcWorker.js'));
+
+class HolographicConsciousnessRealityGenerator {
+  async runCalculations(iterations = 1000) {
+    const [projection, environment] = await Promise.all([
+      pool.exec('projectionLoop', [iterations]),
+      pool.exec('environmentLoop', [iterations]),
+    ]);
+    return { projection, environment };
+  }
+
+  async terminate() {
+    await pool.terminate();
+  }
+}
+
+export { HolographicConsciousnessRealityGenerator };

--- a/server/consciousness/workers/calcWorker.js
+++ b/server/consciousness/workers/calcWorker.js
@@ -1,0 +1,19 @@
+import workerpool from 'workerpool';
+
+function projectionLoop(iterations = 1000) {
+  let sum = 0;
+  for (let i = 0; i < iterations; i++) {
+    sum += Math.sin(i) * Math.cos(i / 2);
+  }
+  return sum;
+}
+
+function environmentLoop(iterations = 1000) {
+  let product = 1;
+  for (let i = 1; i <= iterations; i++) {
+    product = (product * ((i % 100) + 1)) % 1000000;
+  }
+  return product;
+}
+
+workerpool.worker({ projectionLoop, environmentLoop });


### PR DESCRIPTION
## Summary
- add calcWorker implementing projection and environment loops
- use workerpool in holographic consciousness generator to run heavy calculations
- depend on workerpool library

## Testing
- `npm test server/consciousness/__tests__/sigilPersistence.test.cjs` *(fails: Cannot find module '../../FlappyJournal/server/consciousness/sigil-based-code-authenticator.cjs')*

------
https://chatgpt.com/codex/tasks/task_e_6892cf1c98088324ab537dfb7a3b4401