### PR TITLE
refactor: load schemas locally

### DIFF
--- a/FlappyJournal/server/consciousness/holographic-consciousness-reality-generator.cjs
+++ b/FlappyJournal/server/consciousness/holographic-consciousness-reality-generator.cjs
@@ -5,10 +5,17 @@
  * Value: $1.2B+ (Consciousness reality generation)
  */
 
+const path = require('path');
 const { EventEmitter  } = require('events');
 const eventBus = require('./core/ConsciousnessEventBus.cjs');
 const { cognitiveLog  } = require('./modules/CognitiveLog.cjs');
-const { validate  } = require('./utils/validation.cjs');
+const { validate  } = require(path.join(__dirname, '../../../server/consciousness/utils/validation.cjs'));
+const realityRequestSchema = require(
+    path.join(__dirname, '../../../server/consciousness/schemas/reality-request.schema.json')
+);
+const consciousnessStateSchema = require(
+    path.join(__dirname, '../../../server/consciousness/schemas/consciousness-state.schema.json')
+);
 const { initializeRandomness, secureId  } = require('./utils/random.cjs');
 const { saveReality, incrementMetric  } = require('./utils/persistence.cjs');
 const { logger, child as childLogger  } = require('./utils/logger.cjs');
@@ -1664,8 +1671,8 @@ class HolographicConsciousnessRealityGenerator extends EventEmitter {
         try {
             // Validate input schemas
             try {
-                validate('https://flappyjournal.dev/schema/reality-request.json', realityRequest);
-                validate('https://flappyjournal.dev/schema/consciousness-state.json', consciousnessState);
+                validate(realityRequestSchema.$id, realityRequest);
+                validate(consciousnessStateSchema.$id, consciousnessState);
             } catch (error) {
                 validationFailures.inc();
                 return {

--- a/FlappyJournal/server/consciousness/recursive-holographic-reality-embedding.cjs
+++ b/FlappyJournal/server/consciousness/recursive-holographic-reality-embedding.cjs
@@ -4,8 +4,12 @@
  * Implements 7-layer recursive reality embedding with bidirectional connections
  */
 
+const path = require('path');
 const { EventEmitter  } = require('events');
-const { validate  } = require('./utils/validation.cjs');
+const { validate  } = require(path.join(__dirname, '../../../server/consciousness/utils/validation.cjs'));
+const consciousnessSchema = require(
+    path.join(__dirname, '../../../server/consciousness/schemas/consciousness-state.schema.json')
+);
 const { initializeRandomness, secureId  } = require('./utils/random.cjs');
 const { saveReality, savePath, saveField, incrementMetric  } = require('./utils/persistence.cjs');
 const { logger, child as childLogger  } = require('./utils/logger.cjs');
@@ -34,7 +38,7 @@ class RecursiveHolographicRealityEmbedding extends EventEmitter {
 
         // Validate baseReality.consciousnessState
         try {
-            validate('https://flappyjournal.dev/schema/consciousness-state.json', baseReality.consciousnessState);
+            validate(consciousnessSchema.$id, baseReality.consciousnessState);
         } catch (error) {
             throw new Error('SchemaValidationError (base reality consciousnessState): ' + error.message);
         }
@@ -54,7 +58,7 @@ class RecursiveHolographicRealityEmbedding extends EventEmitter {
 
         // Validate generated recursiveConsciousnessState
         try {
-            validate('https://flappyjournal.dev/schema/consciousness-state.json', recursiveConsciousnessState);
+            validate(consciousnessSchema.$id, recursiveConsciousnessState);
         } catch (error) {
             throw new Error('SchemaValidationError (recursiveConsciousnessState): ' + error.message);
         }

--- a/__tests__/schema-validation.test.cjs
+++ b/__tests__/schema-validation.test.cjs
@@ -2,6 +2,18 @@ const path = require('path');
 const { validate } = require(
   path.join(__dirname, '../server/consciousness/utils/validation.cjs')
 );
+const consciousnessSchema = require(
+  path.join(
+    __dirname,
+    '../server/consciousness/schemas/consciousness-state.schema.json'
+  )
+);
+const realityRequestSchema = require(
+  path.join(
+    __dirname,
+    '../server/consciousness/schemas/reality-request.schema.json'
+  )
+);
 
 const validConsciousness = { phi: 0.7, awareness: 0.8, coherence: 0.9, version: 1 };
 const invalidConsciousness = { phi: 1.2, awareness: -0.2, coherence: 2, version: 1 };
@@ -9,13 +21,13 @@ const invalidConsciousness = { phi: 1.2, awareness: -0.2, coherence: 2, version:
 describe('ConsciousnessState schema validation', () => {
   test('valid object passes', () => {
     expect(() =>
-      validate('https://flappyjournal.dev/schema/consciousness-state.json', validConsciousness)
+      validate(consciousnessSchema.$id, validConsciousness)
     ).not.toThrow();
   });
 
   test('invalid object throws', () => {
     expect(() =>
-      validate('https://flappyjournal.dev/schema/consciousness-state.json', invalidConsciousness)
+      validate(consciousnessSchema.$id, invalidConsciousness)
     ).toThrow(/SchemaValidationError/);
   });
 });
@@ -26,13 +38,13 @@ const invalidRequest = { description: "", complexity: 2, dimensions: { spatial: 
 describe('RealityRequest schema validation', () => {
   test('valid object passes', () => {
     expect(() =>
-      validate('https://flappyjournal.dev/schema/reality-request.json', validRequest)
+      validate(realityRequestSchema.$id, validRequest)
     ).not.toThrow();
   });
 
   test('invalid object throws', () => {
     expect(() =>
-      validate('https://flappyjournal.dev/schema/reality-request.json', invalidRequest)
+      validate(realityRequestSchema.$id, invalidRequest)
     ).toThrow(/SchemaValidationError/);
   });
 });


### PR DESCRIPTION
## Summary
- load schema validation tests from local schema files instead of remote URLs
- replace remote schema references in consciousness modules with local imports

## Testing
- `npm test` *(fails: Cannot find module 'semver')*

------
https://chatgpt.com/codex/tasks/task_e_6892cf16dfbc8324aef2b57fff87b5d2