### PR TITLE
feat: add reality generation authz middleware and mTLS config

### DIFF
--- a/FlappyJournal/server/reality-generator-service.cjs
+++ b/FlappyJournal/server/reality-generator-service.cjs
@@ -9,6 +9,9 @@ const { Server  } = require('socket.io');
 const AutonomousImaginationEngine = require('./consciousness/autonomous-imagination-engine.cjs');
 const { HolographicConsciousnessRealityGenerator  } = require('./consciousness/holographic-consciousness-reality-generator.cjs');
 const os = require('os');
+const { verifyScope } = require('../../server/consciousness/utils/authz.cjs');
+
+const requireRealityGenScope = verifyScope('reality.gen');
 
 // Initialize Express app
 const app = express();
@@ -43,7 +46,7 @@ let serviceMetrics = {
 app.use(express.json());
 
 // Health check endpoint
-app.get('/health', (req, res) => {
+app.get('/health', requireRealityGenScope, (req, res) => {
     const uptime = Date.now() - serviceMetrics.startTime;
     res.json({
         status: 'healthy',
@@ -55,7 +58,7 @@ app.get('/health', (req, res) => {
 });
 
 // Get generated realities
-app.get('/api/realities', (req, res) => {
+app.get('/api/realities', requireRealityGenScope, (req, res) => {
     const limit = parseInt(req.query.limit) || 10;
     const realities = imaginationEngine ? imaginationEngine.getGeneratedRealities(limit) : [];
     res.json({
@@ -65,7 +68,7 @@ app.get('/api/realities', (req, res) => {
 });
 
 // Start/stop imagination engine
-app.post('/api/imagination/start', (req, res) => {
+app.post('/api/imagination/start', requireRealityGenScope, (req, res) => {
     if (!imaginationEngine) {
         return res.status(500).json({ error: 'Imagination engine not initialized' });
     }
@@ -74,7 +77,7 @@ app.post('/api/imagination/start', (req, res) => {
     res.json({ status: 'started', message: 'Autonomous imagination engine started' });
 });
 
-app.post('/api/imagination/stop', (req, res) => {
+app.post('/api/imagination/stop', requireRealityGenScope, (req, res) => {
     if (!imaginationEngine) {
         return res.status(500).json({ error: 'Imagination engine not initialized' });
     }
@@ -84,7 +87,7 @@ app.post('/api/imagination/stop', (req, res) => {
 });
 
 // Get imagination engine status
-app.get('/api/imagination/status', (req, res) => {
+app.get('/api/imagination/status', requireRealityGenScope, (req, res) => {
     if (!imaginationEngine) {
         return res.status(500).json({ error: 'Imagination engine not initialized' });
     }
@@ -93,7 +96,7 @@ app.get('/api/imagination/status', (req, res) => {
 });
 
 // Manual reality generation endpoint
-app.post('/api/generate-reality', async (req, res) => {
+app.post('/api/generate-reality', requireRealityGenScope, async (req, res) => {
     try {
         const { request, consciousnessState } = req.body;
         

--- a/k8s/holograph-ingress.yaml
+++ b/k8s/holograph-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: holograph-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    kubernetes.io/ingress.class: istio
+spec:
+  tls:
+    - hosts:
+        - holograph.example.com
+      secretName: holograph-tls
+  rules:
+    - host: holograph.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: holograph-svc-active
+                port:
+                  number: 80

--- a/k8s/holograph-mtls.yaml
+++ b/k8s/holograph-mtls.yaml
@@ -1,0 +1,10 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: holograph-mtls
+spec:
+  selector:
+    matchLabels:
+      app: holograph-gateway
+  mtls:
+    mode: STRICT

--- a/k8s/holograph-rollout.yaml
+++ b/k8s/holograph-rollout.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         app: holograph-gateway
+      annotations:
+        sidecar.istio.io/inject: "true"
     spec:
       containers:
         - name: gateway

--- a/server/consciousness/utils/authz.cjs
+++ b/server/consciousness/utils/authz.cjs
@@ -1,0 +1,54 @@
+const jwt = require('jsonwebtoken');
+const jwksClient = require('jwks-rsa');
+
+const KEYCLOAK_URL = process.env.KEYCLOAK_URL || 'http://localhost:8082';
+const REALM = process.env.KEYCLOAK_REALM || 'featherweight';
+
+const client = jwksClient({
+  jwksUri: `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/certs`,
+  cache: true,
+  cacheMaxEntries: 5,
+  cacheMaxAge: 300000 // 5 minutes
+});
+
+function getKey(header, callback) {
+  client.getSigningKey(header.kid, (err, key) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+    const signingKey = key.publicKey || key.rsaPublicKey;
+    callback(null, signingKey);
+  });
+}
+
+function verifyScope(requiredScope) {
+  return function(req, res, next) {
+    const authHeader = req.headers['authorization'];
+    const token = authHeader && authHeader.split(' ')[1];
+
+    if (!token) {
+      return res.status(401).json({ error: 'Access token required' });
+    }
+
+    jwt.verify(token, getKey, {
+      audience: 'featherweight-frontend',
+      issuer: `${KEYCLOAK_URL}/realms/${REALM}`,
+      algorithms: ['RS256']
+    }, (err, decoded) => {
+      if (err) {
+        return res.status(403).json({ error: 'Invalid token' });
+      }
+
+      const scopes = decoded.scope ? decoded.scope.split(' ') : [];
+      if (!scopes.includes(requiredScope)) {
+        return res.status(403).json({ error: 'Insufficient scope' });
+      }
+
+      req.user = decoded;
+      next();
+    });
+  };
+}
+
+module.exports = { verifyScope };


### PR DESCRIPTION
## Summary
- add verifyScope middleware for reality generation
- secure reality-generator-service endpoints with scope check
- add service mesh mTLS config and cert-manager staging issuer

## Testing
- `npm test` *(fails: Cannot find module semver, 76 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6892cf14359083248a85fafa9436b7bc