### PR TITLE
feat: add reality scene table

### DIFF
--- a/migrations/add_reality_scene_table.sql
+++ b/migrations/add_reality_scene_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS reality_scene (
+    scene_id TEXT PRIMARY KEY,
+    scene_json JSONB NOT NULL,
+    depth INT NOT NULL,
+    parent_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS reality_scene_type_idx ON reality_scene((scene_json->>'type'));

--- a/server/consciousness/persistence/PostgresStore.cjs
+++ b/server/consciousness/persistence/PostgresStore.cjs
@@ -59,6 +59,22 @@ class PostgresStore {
           reset_ts BIGINT NOT NULL
         );`
       );
+
+      // Create reality_scene table for storing scene hierarchy
+      await this.pool.query(
+        `CREATE TABLE IF NOT EXISTS reality_scene (
+          scene_id TEXT PRIMARY KEY,
+          scene_json JSONB NOT NULL,
+          depth INT NOT NULL,
+          parent_id TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        );`
+      );
+
+      // Index scenes by their type field inside JSON
+      await this.pool.query(
+        `CREATE INDEX IF NOT EXISTS reality_scene_type_idx ON reality_scene((scene_json->>'type'));`
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
- add reality_scene table and index to PostgresStore initialization
- add matching migration for reality_scene table

## Testing
- `npm test` *(fails: Cannot find module 'semver')*


------
https://chatgpt.com/codex/tasks/task_e_6892cf088fc88324825bf0f9a00649a9