### PR TITLE
test: add reality persistence test

### DIFF
--- a/server/consciousness/__tests__/test-reality-persistence.cjs
+++ b/server/consciousness/__tests__/test-reality-persistence.cjs
@@ -1,0 +1,60 @@
+/**
+ * Test: Reality Persistence
+ * Verifies that generated scenes persist via PostgresStore across generator restarts.
+ */
+
+const { PostgresStore } = require('../persistence/PostgresStore.cjs');
+
+// Simple scene generator that stores scenes in PostgresStore
+class SceneGenerator {
+  constructor(store) {
+    this.store = store;
+  }
+
+  async generateScene(id) {
+    const scene = { id, createdAt: Date.now() };
+    await this.store.pushToList('scenes', scene);
+    return scene;
+  }
+
+  async loadScenes() {
+    return await this.store.list('scenes');
+  }
+}
+
+describe('Reality Persistence', () => {
+  let store;
+
+  beforeAll(async () => {
+    store = new PostgresStore();
+    await store.ready;
+    // Clean up any existing scenes
+    await store.pool.query("DELETE FROM consciousness_kv WHERE id = $1", ['scenes']);
+  });
+
+  afterAll(async () => {
+    if (store) {
+      await store.pool.query("DELETE FROM consciousness_kv WHERE id = $1", ['scenes']);
+      await store.close();
+    }
+  });
+
+  test('should persist scenes across generator restart', async () => {
+    const generator = new SceneGenerator(store);
+    const totalScenes = 100;
+
+    for (let i = 0; i < totalScenes; i++) {
+      await generator.generateScene(`scene-${i}`);
+    }
+
+    // Simulate restart by closing store and creating new instances
+    await store.close();
+    store = new PostgresStore();
+    await store.ready;
+
+    const restartedGenerator = new SceneGenerator(store);
+    const scenes = await restartedGenerator.loadScenes();
+
+    expect(scenes.length).toBe(totalScenes);
+  });
+});


### PR DESCRIPTION
## Summary
- add reality persistence test verifying PostgresStore reloads scenes after generator restart

## Testing
- `npm test server/consciousness/__tests__/test-reality-persistence.cjs` *(fails: Cannot find module 'semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6892cf0633b88324a60f09c2e5566e92