### PR TITLE
feat: add S3 snapshotter

### DIFF
--- a/server/consciousness/persistence/S3Snapshotter.cjs
+++ b/server/consciousness/persistence/S3Snapshotter.cjs
@@ -1,0 +1,48 @@
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+const { Pool } = require('pg');
+const fs = require('fs');
+
+class S3Snapshotter {
+  constructor(opts = {}) {
+    this.bucket = opts.bucket || process.env.BUCKET;
+    this.intervalMs = opts.intervalMs || 5 * 60 * 1000;
+    this.s3 = opts.s3Client || new S3Client({});
+    this.pool = opts.pool || null;
+    this.timer = null;
+  }
+
+  start() {
+    if (this.timer || !this.bucket) return;
+    this.timer = setInterval(() => {
+      this.snapshot().catch(err => console.error('S3 snapshot failed', err));
+    }, this.intervalMs);
+  }
+
+  async stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+    }
+  }
+
+  async snapshot() {
+    if (!this.bucket) return;
+    if (!this.pool) {
+      this.pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    }
+    const tmpFile = '/tmp/ts.dump.gz';
+    await this.pool.query("COPY (SELECT * FROM reality_scene) TO PROGRAM 'gzip > /tmp/ts.dump.gz'");
+    const fileStream = fs.createReadStream(tmpFile);
+    await this.s3.send(new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: 'reality-snapshots/ts.dump.gz',
+      Body: fileStream
+    }));
+  }
+}
+
+module.exports = S3Snapshotter;

--- a/server/consciousness/persistenceShutdown.cjs
+++ b/server/consciousness/persistenceShutdown.cjs
@@ -1,7 +1,15 @@
 import { shutdown } from './utils/persistence.cjs';
 import { realityWorker } from './utils/queue.cjs';
-['SIGINT', 'SIGTERM'].forEach(sig => process.on(sig, async () => {
-  await shutdown();
-  if (realityWorker && realityWorker.close) await realityWorker.close();
-  process.exit(0);
-}));
+import S3Snapshotter from './persistence/S3Snapshotter.cjs';
+
+const s3Snapshotter = new S3Snapshotter();
+s3Snapshotter.start();
+
+['SIGINT', 'SIGTERM'].forEach(sig =>
+  process.on(sig, async () => {
+    await s3Snapshotter.stop();
+    await shutdown();
+    if (realityWorker && realityWorker.close) await realityWorker.close();
+    process.exit(0);
+  })
+);


### PR DESCRIPTION
## Summary
- periodically dump reality_scene to S3
- register snapshotter with shutdown hooks

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*


------
https://chatgpt.com/codex/tasks/task_e_6892cf04e9588324992d53aed28be0d6