### PR TITLE
Add NATS JetStream values and runbook instructions

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -45,3 +45,16 @@
 ### Rehearsal Schedule
 - Conduct a full rotation rehearsal in staging every March and September.
 - Document lessons learned and update this runbook after each rehearsal.
+
+## NATS JetStream Installation
+
+1. Add the NATS Helm repo:
+   ```bash
+   helm repo add nats https://nats-io.github.io/k8s/helm/charts
+   ```
+2. Install or upgrade the release using the provided values:
+   ```bash
+   helm upgrade --install jetstream nats/nats --namespace nats --create-namespace -f k8s/jetstream/values.yaml
+   ```
+
+This chart enables JetStream and provisions the `reality.gen.request` and `reality.gen.result` subjects.

--- a/k8s/jetstream/values.yaml
+++ b/k8s/jetstream/values.yaml
@@ -1,0 +1,15 @@
+config:
+  jetstream:
+    enabled: true
+
+extraResources:
+  - apiVersion: jetstream.nats.io/v1beta2
+    kind: Stream
+    metadata:
+      name: reality
+    spec:
+      name: reality
+      subjects:
+        - reality.gen.request
+        - reality.gen.result
+      storage: file


### PR DESCRIPTION
## Summary
- add Helm values for NATS with JetStream and reality.gen.* streams
- document JetStream installation steps in runbook

## Testing
- `npm test` *(fails: Cannot find module 'semver')*

------
https://chatgpt.com/codex/tasks/task_e_6892cf04da9c8324abb7288f0d9a6007