### PR TITLE
Activate Architect 4.0 systems by default

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -24,6 +24,7 @@ const axios = require('axios');
 
 // Import UnifiedChatAggregator for multi-container chat routing
 const UnifiedChatAggregator = require('./consciousness/core/UnifiedChatAggregator.cjs');
+const architect40 = require('./architect-4.0-orchestrator.cjs');
 
 // Load environment variables
 const envPath = join(__dirname, '..', '.env');
@@ -124,7 +125,18 @@ class UniversalSystemTerminal {
             
             // Setup universal event bus integration
             this.setupUniversalEventBusIntegration();
-            
+
+            // Activate Architect 4.0 systems by default
+            try {
+                const status = architect40.getStatus();
+                if (!status.isActive) {
+                    await architect40.activate();
+                }
+                console.log('🤖 Architect 4.0 systems active');
+            } catch (err) {
+                console.warn('⚠️ Failed to activate Architect 4.0 systems:', err.message);
+            }
+
             // Initialize readline interface
             this.initializeReadline();
             
@@ -955,9 +967,17 @@ class UniversalSystemTerminal {
             }
             console.log('⚠️ Architect 4.0 status not available');
         } else if (cmd === 'architect activate') {
-            console.log('🤖 Activating Architect 4.0 autonomous systems...');
-            // This is a placeholder. In a real system, this would trigger a complex process.
-            console.log('✅ Architect 4.0 systems activated (placeholder)');
+            try {
+                const status = architect40.getStatus();
+                if (!status.isActive) {
+                    const result = await architect40.activate();
+                    console.log('✅ Architect 4.0 systems activated:', result.timestamp);
+                } else {
+                    console.log('✅ Architect 4.0 systems already active');
+                }
+            } catch (error) {
+                console.error('❌ Failed to activate Architect 4.0 systems:', error.message);
+            }
         } else if (cmd === 'architect components') {
             console.log('🤖 Architect 4.0 Components:');
             console.log('  • Autonomous Coding Agent');


### PR DESCRIPTION
## Summary
- import Architect 4.0 orchestrator in the universal terminal
- activate Architect 4.0 systems on terminal startup
- replace placeholder command logic with real activation

## Testing
- `npm test` *(fails: Cannot find module 'semver', missing type declarations, and multiple test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc3179308324a3ca99bc73826df2