### PR TITLE
feat: wire selfcode trigger

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -973,7 +973,15 @@ class UniversalSystemTerminal {
 
         if (cmd === 'selfcode trigger') {
             console.log('🔄 Triggering self-coding sequence...');
-            console.log('✅ Self-coding sequence initiated (placeholder)');
+            try {
+                const scriptPath = join(__dirname, 'trigger-autonomous-coding.cjs');
+                const { stdout, stderr } = await execAsync(`node ${scriptPath}`);
+                if (stdout) console.log(stdout);
+                if (stderr) console.error(stderr);
+                console.log('✅ Self-coding sequence initiated');
+            } catch (error) {
+                console.error('❌ Self-coding trigger failed:', error.message);
+            }
         } else if (cmd === 'selfcode status') {
             console.log('📊 Self-coding system status:');
             console.log('  ✅ AutonomousCodingAgent: Active');


### PR DESCRIPTION
## Summary
- Invoke real self-coding subsystem when `selfcode trigger` runs

## Testing
- `npm test` *(fails: Cannot find module 'semver')*
- `pre-commit run --files FlappyJournal/server/universal-system-terminal.cjs` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893bbf940048324b91a27009ed64c4f