### PR TITLE
feat: add core module listing

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -933,6 +933,21 @@ class UniversalSystemTerminal {
                 return;
             }
             console.log('⚠️ Complete integration not available');
+        } else if (cmd === 'modules core') {
+            if (this.completeIntegration) {
+                const status = this.completeIntegration.getCompleteSystemStatus();
+                const modules = (status.consciousnessModules || []).filter(m => m.classification === 'consciousness-core');
+
+                console.log(`🧠 Consciousness-Core Modules (${modules.length}):`);
+                modules.forEach((module, index) => {
+                    const statusIcon = module.integrated ? '✅' : '⚠️';
+                    const chatIcon = module.universalChatAccess ? '💬' : '❌';
+                    const aiIcon = module.aiIntegrated ? '🤖' : '❌';
+                    console.log(`  ${index + 1}. ${statusIcon}${chatIcon}${aiIcon} ${module.name}`);
+                });
+                return;
+            }
+            console.log('⚠️ Complete integration not available');
         }
     }
 


### PR DESCRIPTION
## Summary
- extend module command handler with `modules core` option to display consciousness-core modules

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*


------
https://chatgpt.com/codex/tasks/task_e_6893bbdf34b08324af90ee05febda3dc