### PR TITLE
feat: add generated module filter

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -933,6 +933,26 @@ class UniversalSystemTerminal {
                 return;
             }
             console.log('⚠️ Complete integration not available');
+        } else if (cmd === 'modules generated') {
+            if (this.completeIntegration) {
+                const status = this.completeIntegration.getCompleteSystemStatus();
+                const modules = (status.consciousnessModules || []).filter(m =>
+                    m.generated || m.filePath || m.registration
+                );
+
+                console.log(`🧬 Generated Modules (${modules.length}):`);
+                modules.forEach((module, index) => {
+                    const name = module.registration?.registration?.name || module.name || module.fileName;
+                    const statusIcon = (module.integrated || module.status === 'registered') ? '✅' : '⚠️';
+                    console.log(`  ${index + 1}. ${statusIcon} ${name}`);
+                });
+
+                if (modules.length === 0) {
+                    console.log('  No generated modules found');
+                }
+                return;
+            }
+            console.log('⚠️ Complete integration not available');
         }
     }
 


### PR DESCRIPTION
## Summary
- support `modules generated` command to show only generated modules

## Testing
- `npm test` *(fails: Cannot find module 'semver')*

------
https://chatgpt.com/codex/tasks/task_e_6893bbd5f4c0832490ae64a4d990ff4d