### PR TITLE
feat: add ui refresh command handling

### DIFF
--- a/FlappyJournal/server/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/server/system-wide-integration-orchestrator.cjs
@@ -937,11 +937,28 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
     
     async handleInterfaceCommand(command) {
         // Handle interface commands from universal chat
-        this.universalEventBus.emit('interface:command_completed', {
-            command,
-            result: this.systemLayers.interfaces,
-            success: true
-        });
+        switch (command.type) {
+            case 'refresh':
+                // Trigger interface refresh actions
+                this.universalEventBus.emit('interface:refresh', {
+                    command,
+                    timestamp: Date.now()
+                });
+                this.universalEventBus.emit('interface:command_completed', {
+                    command,
+                    result: { refreshed: true },
+                    success: true
+                });
+                break;
+
+            default:
+                this.universalEventBus.emit('interface:command_completed', {
+                    command,
+                    result: this.systemLayers.interfaces,
+                    success: true
+                });
+                break;
+        }
     }
     
     async handleSystemCommand(command) {

--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -839,7 +839,7 @@ class UniversalSystemTerminal {
     
     async handleInterfaceCommand(cmd) {
         console.log('\n🖥️ INTERFACE COMMAND PROCESSING...');
-        
+
         if (cmd === 'interface status' || cmd === 'ui status') {
             if (this.systemOrchestrator) {
                 const eventBus = this.systemOrchestrator.getUniversalEventBus();
@@ -851,6 +851,19 @@ class UniversalSystemTerminal {
                 return;
             }
             console.log('⚠️ Interface status not available');
+        }
+
+        if (cmd === 'ui refresh' || cmd === 'interface refresh') {
+            if (this.systemOrchestrator) {
+                const eventBus = this.systemOrchestrator.getUniversalEventBus();
+                eventBus.emit('chat:interface_command', {
+                    type: 'refresh',
+                    timestamp: Date.now()
+                });
+                console.log('🔄 Interface refresh event emitted');
+                return;
+            }
+            console.log('⚠️ Interface refresh not available');
         }
     }
 

--- a/FlappyJournal/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/system-wide-integration-orchestrator.cjs
@@ -937,11 +937,28 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
     
     async handleInterfaceCommand(command) {
         // Handle interface commands from universal chat
-        this.universalEventBus.emit('interface:command_completed', {
-            command,
-            result: this.systemLayers.interfaces,
-            success: true
-        });
+        switch (command.type) {
+            case 'refresh':
+                // Trigger interface refresh actions
+                this.universalEventBus.emit('interface:refresh', {
+                    command,
+                    timestamp: Date.now()
+                });
+                this.universalEventBus.emit('interface:command_completed', {
+                    command,
+                    result: { refreshed: true },
+                    success: true
+                });
+                break;
+
+            default:
+                this.universalEventBus.emit('interface:command_completed', {
+                    command,
+                    result: this.systemLayers.interfaces,
+                    success: true
+                });
+                break;
+        }
     }
     
     async handleSystemCommand(command) {


### PR DESCRIPTION
## Summary
- support `ui refresh` in universal system terminal to emit interface refresh events
- orchestrator processes interface refresh commands and broadcasts through event bus

## Testing
- `npm test` *(fails: Cannot find module '/workspace/August9teen/node_modules/semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6893bbc386d48324b0dc3771ec74de57