### PR TITLE
feat: allow restarting services

### DIFF
--- a/FlappyJournal/server/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/server/system-wide-integration-orchestrator.cjs
@@ -928,11 +928,32 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
     
     async handleServiceCommand(command) {
         // Handle service commands from universal chat
-        this.universalEventBus.emit('service:command_completed', {
-            command,
-            result: this.systemLayers.services,
-            success: true
-        });
+        switch (command.type) {
+            case 'status':
+                this.universalEventBus.emit('service:command_completed', {
+                    command,
+                    result: this.systemLayers.services,
+                    success: true
+                });
+                break;
+
+            case 'restart':
+                try {
+                    const result = await this.deepSystemAccess?.processManagement?.restartService(command.service);
+                    this.universalEventBus.emit('service:command_completed', {
+                        command,
+                        result,
+                        success: true
+                    });
+                } catch (error) {
+                    this.universalEventBus.emit('service:command_completed', {
+                        command,
+                        error: error.message,
+                        success: false
+                    });
+                }
+                break;
+        }
     }
     
     async handleInterfaceCommand(command) {

--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -817,6 +817,16 @@ class UniversalSystemTerminal {
                     timestamp: Date.now()
                 });
             }
+        } else if (cmd.startsWith('service restart ')) {
+            const serviceName = cmd.replace('service restart ', '').trim();
+            if (this.systemOrchestrator) {
+                const eventBus = this.systemOrchestrator.getUniversalEventBus();
+                eventBus.emit('chat:service_command', {
+                    type: 'restart',
+                    service: serviceName,
+                    timestamp: Date.now()
+                });
+            }
         }
     }
     

--- a/FlappyJournal/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/system-wide-integration-orchestrator.cjs
@@ -928,11 +928,32 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
     
     async handleServiceCommand(command) {
         // Handle service commands from universal chat
-        this.universalEventBus.emit('service:command_completed', {
-            command,
-            result: this.systemLayers.services,
-            success: true
-        });
+        switch (command.type) {
+            case 'status':
+                this.universalEventBus.emit('service:command_completed', {
+                    command,
+                    result: this.systemLayers.services,
+                    success: true
+                });
+                break;
+
+            case 'restart':
+                try {
+                    const result = await this.deepSystemAccess?.processManagement?.restartService(command.service);
+                    this.universalEventBus.emit('service:command_completed', {
+                        command,
+                        result,
+                        success: true
+                    });
+                } catch (error) {
+                    this.universalEventBus.emit('service:command_completed', {
+                        command,
+                        error: error.message,
+                        success: false
+                    });
+                }
+                break;
+        }
     }
     
     async handleInterfaceCommand(command) {


### PR DESCRIPTION
## Summary
- allow restarting services from the universal system terminal
- handle service restart requests in the system-wide orchestrator

## Testing
- `npm test` *(fails: Cannot find module '/workspace/August9teen/node_modules/semver/semver.js', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6893bbb8e8348324be9e56b82d053812