### PR TITLE
feat: add error handling for memory integration

### DIFF
--- a/FlappyJournal/server/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/server/system-wide-integration-orchestrator.cjs
@@ -380,16 +380,25 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 break;
                 
             case 'integrate_memory':
-                const integration = await orchestrator.integrateMemoryWithReality(
-                    command.memory,
-                    command.realityId,
-                    command.parameters
-                );
-                this.universalEventBus.emit('consciousness:command_completed', {
-                    command,
-                    result: integration,
-                    success: true
-                });
+                try {
+                    const integration = await orchestrator.integrateMemoryWithReality(
+                        command.memory,
+                        command.realityId,
+                        command.parameters
+                    );
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        result: integration,
+                        success: true
+                    });
+                } catch (error) {
+                    console.error('❌ Memory integration failed:', error);
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        error: error.message || error,
+                        success: false
+                    });
+                }
                 break;
                 
             default:

--- a/FlappyJournal/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/system-wide-integration-orchestrator.cjs
@@ -380,16 +380,25 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 break;
                 
             case 'integrate_memory':
-                const integration = await orchestrator.integrateMemoryWithReality(
-                    command.memory,
-                    command.realityId,
-                    command.parameters
-                );
-                this.universalEventBus.emit('consciousness:command_completed', {
-                    command,
-                    result: integration,
-                    success: true
-                });
+                try {
+                    const integration = await orchestrator.integrateMemoryWithReality(
+                        command.memory,
+                        command.realityId,
+                        command.parameters
+                    );
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        result: integration,
+                        success: true
+                    });
+                } catch (error) {
+                    console.error('❌ Memory integration failed:', error);
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        error: error.message || error,
+                        success: false
+                    });
+                }
                 break;
                 
             default:


### PR DESCRIPTION
## Summary
- catch and log errors when integrating memory with realities

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6893bbb580d88324afdd1ac679d9fde9