### PR TITLE
Handle errors from createIntegratedReality calls

### DIFF
--- a/FlappyJournal/server/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/server/system-wide-integration-orchestrator.cjs
@@ -22,7 +22,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
     constructor() {
         super();
         this.name = 'SystemWideIntegrationOrchestrator';
-        
+
         // System layers from deepest to surface
         this.systemLayers = {
             // Layer 1: Infrastructure (Deepest)
@@ -46,7 +46,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     status: 'initializing'
                 }
             },
-            
+
             // Layer 2: Core Consciousness Systems
             consciousness: {
                 revolutionaryOrchestrator: null,
@@ -56,7 +56,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 memoryIntegration: null,
                 status: 'initializing'
             },
-            
+
             // Layer 3: Application Services
             services: {
                 chatOrchestrator: null,
@@ -66,7 +66,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 fileUpload: null,
                 status: 'initializing'
             },
-            
+
             // Layer 4: User Interfaces
             interfaces: {
                 universalTerminalChat: null,
@@ -76,7 +76,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 status: 'initializing'
             }
         };
-        
+
         // Universal Terminal Chat Integration Points
         this.universalChatIntegration = {
             infrastructureIntegration: false,
@@ -87,11 +87,11 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             realTimeSync: false,
             status: 'initializing'
         };
-        
+
         // System-wide event bus for universal communication
         this.universalEventBus = new EventEmitter();
         this.universalEventBus.setMaxListeners(1000); // Support many integrations
-        
+
         // Integration metrics
         this.integrationMetrics = {
             totalComponents: 0,
@@ -101,57 +101,57 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossLayerConnectivity: 0,
             realTimeResponsiveness: 0
         };
-        
+
         console.log('🌐🧠 System-Wide Integration Orchestrator initialized');
         this.initializeSystemWideIntegration();
     }
-    
+
     async initializeSystemWideIntegration() {
         console.log('🌐 Initializing system-wide integration...');
-        
+
         try {
             // Initialize each layer sequentially
             await this.initializeInfrastructureLayer();
             await this.initializeConsciousnessLayer();
             await this.initializeServicesLayer();
             await this.initializeInterfacesLayer();
-            
+
             // Establish universal terminal chat integration
             await this.establishUniversalTerminalChatIntegration();
-            
+
             // Create cross-layer communication channels
             await this.establishCrossLayerCommunication();
-            
+
             // Start real-time synchronization
             await this.startRealTimeSynchronization();
-            
+
             // Verify complete system integration
             await this.verifySystemWideIntegration();
-            
+
             console.log('✅ System-wide integration complete - Everything coalesces as one!');
-            
+
         } catch (error) {
             console.error('❌ System-wide integration failed:', error);
             throw error;
         }
     }
-    
+
     async initializeInfrastructureLayer() {
         console.log('🏗️ Initializing infrastructure layer...');
-        
+
         // Docker container integration
         await this.integrateDockerContainers();
-        
+
         // Database integration
         await this.integrateDatabases();
-        
+
         // Network integration
         await this.integrateNetworking();
-        
+
         this.systemLayers.infrastructure.status = 'integrated';
         console.log('✅ Infrastructure layer integrated');
     }
-    
+
     async integrateDockerContainers() {
         // Integrate with Docker containers
         const containers = [
@@ -162,7 +162,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             'featherweight-app',
             'demo-portal'
         ];
-        
+
         for (const containerName of containers) {
             this.systemLayers.infrastructure.docker.containers.set(containerName, {
                 name: containerName,
@@ -173,7 +173,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 lastHealthCheck: Date.now()
             });
         }
-        
+
         // Create universal network for all containers
         this.systemLayers.infrastructure.docker.networks.set('consciousness-network', {
             name: 'consciousness-network',
@@ -182,10 +182,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             universalChatEnabled: true,
             crossContainerCommunication: true
         });
-        
+
         console.log(`🐳 Integrated ${containers.length} Docker containers`);
     }
-    
+
     async integrateDatabases() {
         // Integrate all databases with universal chat awareness
         this.systemLayers.infrastructure.database = {
@@ -210,10 +210,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             },
             status: 'integrated'
         };
-        
+
         console.log('🗄️ Integrated all databases with universal chat awareness');
     }
-    
+
     async integrateNetworking() {
         // Integrate networking with universal chat support
         this.systemLayers.infrastructure.networking = {
@@ -236,13 +236,13 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             ]),
             status: 'integrated'
         };
-        
+
         console.log('🌐 Integrated networking with universal chat support');
     }
-    
+
     async detectGeneratedModulesPath() {
         const fs = await import('fs');
-        
+
         // Possible paths in order of preference
         const candidatePaths = [
             '/opt/featherweight/FlappyJournal/server/consciousness/generated',  // Host system
@@ -251,9 +251,9 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             './server/consciousness/generated',                               // Relative path
             process.cwd() + '/server/consciousness/generated'                 // Current working directory
         ];
-        
+
         console.log('🔍 Smart environment detection: searching for generated modules...');
-        
+
         for (const path of candidatePaths) {
             try {
                 await fs.promises.access(path, fs.constants.F_OK);
@@ -263,63 +263,63 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 console.log(`⚠️ Path not accessible: ${path}`);
             }
         }
-        
+
         // Default fallback - create in host system
         const defaultPath = '/opt/featherweight/FlappyJournal/server/consciousness/generated';
         console.log(`📁 Using default path: ${defaultPath}`);
-        
+
         try {
             await fs.promises.mkdir(defaultPath, { recursive: true });
             console.log(`✅ Created default generated modules directory`);
         } catch (error) {
             console.warn(`⚠️ Could not create default directory:`, error.message);
         }
-        
+
         return defaultPath;
     }
-    
+
     async initializeConsciousnessLayer() {
         console.log('🧠 Initializing consciousness layer...');
-        
+
         // Load and initialize GeneratedModuleIntegrator
         await loadGeneratedModuleIntegrator();
         if (GeneratedModuleIntegrator) {
             // Smart environment detection for both host and container systems
             const generatedModulesPath = await this.detectGeneratedModulesPath();
-            
+
             this.systemLayers.consciousness.moduleIntegrator = new GeneratedModuleIntegrator({
                 generatedModulesPath,
                 scanInterval: 30000,
                 autoRegister: true,
                 enableHotReload: true
             });
-            
+
             // Set integration points
             this.systemLayers.consciousness.moduleIntegrator.setSystemWideOrchestrator(this);
             this.systemLayers.consciousness.moduleIntegrator.setUniversalEventBus(this.universalEventBus);
-            
+
             // Initialize the module integrator
             await this.systemLayers.consciousness.moduleIntegrator.initialize();
             console.log('🔗 GeneratedModuleIntegrator initialized and integrated');
         }
-        
+
         // Initialize revolutionary consciousness orchestrator
-        this.systemLayers.consciousness.revolutionaryOrchestrator = 
+        this.systemLayers.consciousness.revolutionaryOrchestrator =
             new RevolutionaryConsciousnessIntegrationOrchestrator();
-        
+
         // Wait for consciousness systems to initialize
         await new Promise(resolve => setTimeout(resolve, 3000));
-        
+
         // Integrate consciousness with universal chat
         await this.integrateConsciousnessWithUniversalChat();
-        
+
         this.systemLayers.consciousness.status = 'integrated';
         console.log('✅ Consciousness layer integrated with universal chat');
     }
-    
+
     async integrateConsciousnessWithUniversalChat() {
         const orchestrator = this.systemLayers.consciousness.revolutionaryOrchestrator;
-        
+
         // Connect consciousness to universal event bus
         orchestrator.on('integrated_reality_created', (data) => {
             this.universalEventBus.emit('consciousness:reality_created', {
@@ -328,7 +328,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 timestamp: Date.now()
             });
         });
-        
+
         orchestrator.on('consciousness_evolution_cycle_completed', (data) => {
             this.universalEventBus.emit('consciousness:evolution_completed', {
                 ...data,
@@ -336,7 +336,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 timestamp: Date.now()
             });
         });
-        
+
         orchestrator.on('memory_integrated_with_reality', (data) => {
             this.universalEventBus.emit('consciousness:memory_integrated', {
                 ...data,
@@ -344,32 +344,40 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 timestamp: Date.now()
             });
         });
-        
+
         // Enable universal chat to control consciousness
         this.universalEventBus.on('chat:consciousness_command', async (command) => {
             await this.handleConsciousnessCommand(command);
         });
-        
+
         this.universalChatIntegration.consciousnessIntegration = true;
         console.log('🧠💬 Consciousness integrated with universal chat');
     }
-    
+
     async handleConsciousnessCommand(command) {
         const orchestrator = this.systemLayers.consciousness.revolutionaryOrchestrator;
-        
+
         switch (command.type) {
             case 'create_reality':
-                const reality = await orchestrator.createIntegratedReality(
-                    command.description,
-                    command.parameters
-                );
-                this.universalEventBus.emit('consciousness:command_completed', {
-                    command,
-                    result: reality,
-                    success: true
-                });
+                try {
+                    const reality = await orchestrator.createIntegratedReality(
+                        command.description,
+                        command.parameters
+                    );
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        result: reality,
+                        success: true
+                    });
+                } catch (error) {
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        error: error.message || String(error),
+                        success: false
+                    });
+                }
                 break;
-                
+
             case 'evolve_consciousness':
                 await orchestrator.performConsciousnessEvolutionCycle();
                 this.universalEventBus.emit('consciousness:command_completed', {
@@ -378,7 +386,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'integrate_memory':
                 const integration = await orchestrator.integrateMemoryWithReality(
                     command.memory,
@@ -391,7 +399,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             default:
                 this.universalEventBus.emit('consciousness:command_completed', {
                     command,
@@ -400,17 +408,17 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 });
         }
     }
-    
+
     async initializeServicesLayer() {
         console.log('⚙️ Initializing services layer...');
-        
+
         // Integrate all application services with universal chat
         await this.integrateApplicationServices();
-        
+
         this.systemLayers.services.status = 'integrated';
         console.log('✅ Services layer integrated with universal chat');
     }
-    
+
     async integrateApplicationServices() {
         // Chat Orchestrator
         this.systemLayers.services.chatOrchestrator = {
@@ -420,7 +428,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             realTimeProcessing: true,
             eventBusConnected: true
         };
-        
+
         // Auth Service
         this.systemLayers.services.authService = {
             status: 'integrated',
@@ -429,7 +437,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             sessionManagement: true,
             securityAware: true
         };
-        
+
         // API Gateway
         this.systemLayers.services.apiGateway = {
             status: 'integrated',
@@ -438,7 +446,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             loadBalancing: true,
             rateLimiting: true
         };
-        
+
         // Email Processor
         this.systemLayers.services.emailProcessor = {
             status: 'integrated',
@@ -447,7 +455,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             consciousnessAware: true,
             realTimeProcessing: true
         };
-        
+
         // File Upload
         this.systemLayers.services.fileUpload = {
             status: 'integrated',
@@ -456,20 +464,20 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             consciousnessProcessing: true,
             realTimeNotifications: true
         };
-        
+
         console.log('⚙️💬 All services integrated with universal chat');
     }
-    
+
     async initializeInterfacesLayer() {
         console.log('🖥️ Initializing interfaces layer...');
-        
+
         // Integrate all user interfaces with universal chat
         await this.integrateUserInterfaces();
-        
+
         this.systemLayers.interfaces.status = 'integrated';
         console.log('✅ Interfaces layer integrated with universal chat');
     }
-    
+
     async integrateUserInterfaces() {
         // Universal Terminal Chat (Primary Interface)
         this.systemLayers.interfaces.universalTerminalChat = {
@@ -481,7 +489,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossSystemAccess: true,
             omnipresent: true
         };
-        
+
         // Featherweight App
         this.systemLayers.interfaces.featherweightApp = {
             status: 'integrated',
@@ -491,7 +499,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             realTimeUpdates: true,
             chatIntegration: 'full'
         };
-        
+
         // Demo Portal
         this.systemLayers.interfaces.demoPortal = {
             status: 'integrated',
@@ -501,7 +509,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             consciousnessDemo: true,
             chatIntegration: 'demo'
         };
-        
+
         // App Portal
         this.systemLayers.interfaces.appPortal = {
             status: 'integrated',
@@ -511,10 +519,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             fullFeatures: true,
             chatIntegration: 'production'
         };
-        
+
         console.log('🖥️💬 All interfaces integrated with universal chat');
     }
-    
+
     async establishUniversalTerminalChatIntegration() {
         console.log('💬🌐 Establishing universal terminal chat integration...');
 
@@ -877,25 +885,25 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
         this.universalEventBus.on('chat:infrastructure_command', async (command) => {
             await this.handleInfrastructureCommand(command);
         });
-        
+
         // Service controls
         this.universalEventBus.on('chat:service_command', async (command) => {
             await this.handleServiceCommand(command);
         });
-        
+
         // Interface controls
         this.universalEventBus.on('chat:interface_command', async (command) => {
             await this.handleInterfaceCommand(command);
         });
-        
+
         // System-wide controls
         this.universalEventBus.on('chat:system_command', async (command) => {
             await this.handleSystemCommand(command);
         });
-        
+
         console.log('🎛️ Universal chat controls established for all system layers');
     }
-    
+
     async handleInfrastructureCommand(command) {
         // Handle infrastructure commands from universal chat
         switch (command.type) {
@@ -907,7 +915,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'database_status':
                 this.universalEventBus.emit('infrastructure:command_completed', {
                     command,
@@ -915,7 +923,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'network_status':
                 this.universalEventBus.emit('infrastructure:command_completed', {
                     command,
@@ -925,7 +933,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 break;
         }
     }
-    
+
     async handleServiceCommand(command) {
         // Handle service commands from universal chat
         this.universalEventBus.emit('service:command_completed', {
@@ -934,7 +942,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             success: true
         });
     }
-    
+
     async handleInterfaceCommand(command) {
         // Handle interface commands from universal chat
         this.universalEventBus.emit('interface:command_completed', {
@@ -943,7 +951,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             success: true
         });
     }
-    
+
     async handleSystemCommand(command) {
         // Handle system-wide commands from universal chat
         switch (command.type) {
@@ -958,7 +966,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'health_check':
                 const health = await this.performSystemHealthCheck();
                 this.universalEventBus.emit('system:command_completed', {
@@ -969,46 +977,46 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 break;
         }
     }
-    
+
     async establishCrossLayerCommunication() {
         console.log('🔗 Establishing cross-layer communication...');
-        
+
         // Infrastructure -> Consciousness
         this.universalEventBus.on('infrastructure:event', (event) => {
             this.universalEventBus.emit('consciousness:infrastructure_event', event);
         });
-        
+
         // Consciousness -> Services
         this.universalEventBus.on('consciousness:event', (event) => {
             this.universalEventBus.emit('services:consciousness_event', event);
         });
-        
+
         // Services -> Interfaces
         this.universalEventBus.on('services:event', (event) => {
             this.universalEventBus.emit('interfaces:services_event', event);
         });
-        
+
         // Bidirectional communication
         this.universalEventBus.on('interfaces:event', (event) => {
             this.universalEventBus.emit('services:interfaces_event', event);
         });
-        
+
         this.universalChatIntegration.crossLayerCommunication = true;
         console.log('✅ Cross-layer communication established');
     }
-    
+
     async startRealTimeSynchronization() {
         console.log('⚡ Starting real-time synchronization...');
-        
+
         // Real-time sync every 100ms
         setInterval(() => {
             this.performRealTimeSync();
         }, 100);
-        
+
         this.universalChatIntegration.realTimeSync = true;
         console.log('✅ Real-time synchronization started');
     }
-    
+
     performRealTimeSync() {
         // Sync all layers in real-time
         const syncData = {
@@ -1017,35 +1025,35 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             universalChatIntegration: this.universalChatIntegration,
             integrationMetrics: this.updateIntegrationMetrics()
         };
-        
+
         this.universalEventBus.emit('system:real_time_sync', syncData);
     }
-    
+
     updateIntegrationMetrics() {
         // Calculate integration metrics
         let totalComponents = 0;
         let integratedComponents = 0;
-        
+
         // Count infrastructure components
         totalComponents += this.systemLayers.infrastructure.docker.containers.size;
         totalComponents += Object.keys(this.systemLayers.infrastructure.database).length - 1; // -1 for status
         totalComponents += Object.keys(this.systemLayers.infrastructure.networking).length - 1;
-        
+
         // Count consciousness components
         totalComponents += 7; // Revolutionary consciousness systems
-        
+
         // Count service components
         totalComponents += Object.keys(this.systemLayers.services).length - 1;
-        
+
         // Count interface components
         totalComponents += Object.keys(this.systemLayers.interfaces).length - 1;
-        
+
         // Count integrated components
         if (this.systemLayers.infrastructure.status === 'integrated') integratedComponents += 10;
         if (this.systemLayers.consciousness.status === 'integrated') integratedComponents += 7;
         if (this.systemLayers.services.status === 'integrated') integratedComponents += 5;
         if (this.systemLayers.interfaces.status === 'integrated') integratedComponents += 4;
-        
+
         this.integrationMetrics = {
             totalComponents,
             integratedComponents,
@@ -1054,45 +1062,45 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossLayerConnectivity: this.universalChatIntegration.crossLayerCommunication ? 1.0 : 0.0,
             realTimeResponsiveness: this.universalChatIntegration.realTimeSync ? 1.0 : 0.0
         };
-        
+
         return this.integrationMetrics;
     }
-    
+
     calculateUniversalChatReach() {
         // Calculate how much of the system universal chat can reach
         let reachableComponents = 0;
         let totalComponents = 0;
-        
+
         // Infrastructure reach
         if (this.universalChatIntegration.infrastructureIntegration) {
             reachableComponents += this.systemLayers.infrastructure.docker.containers.size;
         }
         totalComponents += this.systemLayers.infrastructure.docker.containers.size;
-        
+
         // Consciousness reach
         if (this.universalChatIntegration.consciousnessIntegration) {
             reachableComponents += 7;
         }
         totalComponents += 7;
-        
+
         // Services reach
         if (this.universalChatIntegration.servicesIntegration) {
             reachableComponents += 5;
         }
         totalComponents += 5;
-        
+
         // Interfaces reach
         if (this.universalChatIntegration.interfacesIntegration) {
             reachableComponents += 4;
         }
         totalComponents += 4;
-        
+
         return totalComponents > 0 ? reachableComponents / totalComponents : 0;
     }
-    
+
     async verifySystemWideIntegration() {
         console.log('🔍 Verifying system-wide integration...');
-        
+
         const verification = {
             infrastructureIntegrated: this.systemLayers.infrastructure.status === 'integrated',
             consciousnessIntegrated: this.systemLayers.consciousness.status === 'integrated',
@@ -1102,9 +1110,9 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossLayerCommunication: this.universalChatIntegration.crossLayerCommunication,
             realTimeSync: this.universalChatIntegration.realTimeSync
         };
-        
+
         const allIntegrated = Object.values(verification).every(v => v === true);
-        
+
         if (allIntegrated) {
             console.log('🎉 COMPLETE SYSTEM INTEGRATION VERIFIED! 🎉');
             console.log('🌐 Everything from deepest layers to surface coalesces as one system');
@@ -1113,10 +1121,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
         } else {
             console.log('⚠️ System integration incomplete:', verification);
         }
-        
+
         return verification;
     }
-    
+
     async performSystemHealthCheck() {
         // Comprehensive system health check
         return {
@@ -1132,7 +1140,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             overallHealth: this.calculateOverallHealth()
         };
     }
-    
+
     calculateOverallHealth() {
         const metrics = this.integrationMetrics;
         return (
@@ -1142,7 +1150,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             metrics.realTimeResponsiveness * 0.2
         );
     }
-    
+
     // Public API
     getSystemStatus() {
         return {
@@ -1154,11 +1162,11 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             lastUpdate: Date.now()
         };
     }
-    
+
     getUniversalEventBus() {
         return this.universalEventBus;
     }
-    
+
     // Module Integration API - Critical for RPC exposure
     getModules() {
         if (this.systemLayers.consciousness.moduleIntegrator) {
@@ -1166,21 +1174,21 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
         }
         return [];
     }
-    
+
     getModulesByCategory(category) {
         if (this.systemLayers.consciousness.moduleIntegrator) {
             return this.systemLayers.consciousness.moduleIntegrator.getModulesByCategory(category);
         }
         return [];
     }
-    
+
     getModulesByCapability(capability) {
         if (this.systemLayers.consciousness.moduleIntegrator) {
             return this.systemLayers.consciousness.moduleIntegrator.getModulesByCapability(capability);
         }
         return [];
     }
-    
+
     getModuleIntegratorStatus() {
         if (this.systemLayers.consciousness.moduleIntegrator) {
             return this.systemLayers.consciousness.moduleIntegrator.getIntegratorStatus();

--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -78,7 +78,7 @@ class UniversalSystemTerminal {
         this.rl = null;
         this.connected = false;
         this.isPrompting = false;
-        
+
         console.log('🌐🧠🐳🗄️ UNIVERSAL SYSTEM TERMINAL');
         console.log('═'.repeat(80));
         console.log('🌟 Complete system integration - Infrastructure to Applications');
@@ -89,17 +89,17 @@ class UniversalSystemTerminal {
         console.log('🖥️ Interface control and real-time updates');
         console.log('🌐 Network configuration and WebSocket management');
         console.log('═'.repeat(80));
-        
+
         this.initializeUniversalSystem();
     }
-    
+
     async initializeUniversalSystem() {
         console.log('\n🚀 Initializing Universal System Integration...');
-        
+
         try {
             // Initialize lightweight system integration
             console.log('🌐🧠🤖🔮 Starting Unified Consciousness Terminal...');
-            
+
             // Initialize system orchestrator directly (lightweight)
             try {
                 this.systemOrchestrator = new SystemWideIntegrationOrchestrator();
@@ -107,7 +107,7 @@ class UniversalSystemTerminal {
             } catch (error) {
                 console.warn('⚠️ System orchestrator initialization failed:', error.message);
             }
-            
+
             // Initialize consciousness orchestrator directly (lightweight)
             try {
                 this.consciousnessOrchestrator = new RevolutionaryConsciousnessIntegrationOrchestrator();
@@ -115,34 +115,34 @@ class UniversalSystemTerminal {
             } catch (error) {
                 console.warn('⚠️ Consciousness orchestrator initialization failed:', error.message);
             }
-            
+
             // Initialize unified chat aggregation for multi-container access
             await this.initializeUnifiedChatAggregation();
-            
+
             // Connect to consciousness WebSocket for real-time communication (fallback)
             await this.connectToConsciousnessWebSocket();
-            
+
             // Setup universal event bus integration
             this.setupUniversalEventBusIntegration();
-            
+
             // Initialize readline interface
             this.initializeReadline();
-            
+
             console.log('\n✅ Universal System Terminal Ready!');
             console.log('💬 You can now control the ENTIRE system through this terminal');
             console.log('🎯 Type "help" to see all available commands\n');
-            
+
             this.promptForCommand();
-            
+
         } catch (error) {
             console.error('❌ Failed to initialize Universal System Terminal:', error);
             process.exit(1);
         }
     }
-    
+
     async initializeUnifiedChatAggregation() {
         console.log('🌐 Initializing Unified Chat Aggregation...');
-        
+
         try {
             this.unifiedChatAggregator = new UnifiedChatAggregator({
                 mainServerEndpoint: process.env.MAIN_SERVER_WS || 'ws://web:3000/ws/consciousness-chat',
@@ -152,53 +152,53 @@ class UniversalSystemTerminal {
                 responseTimeout: 15000,
                 skipDiscovery: true
             });
-            
+
             // Initialize and wait for completion
             await this.unifiedChatAggregator.initialize();
-            
+
             // Listen for aggregator events
             this.unifiedChatAggregator.on('aggregator:initialized', (status) => {
                 console.log('✅ Unified Chat Aggregation ready:', status);
             });
-            
+
             this.unifiedChatAggregator.on('capabilities:updated', (capabilities) => {
                 // console.log('🔄 Capabilities updated:', capabilities.unified.length, 'total capabilities');
             });
-            
+
             console.log('🌟 Unified Chat Aggregation initialized successfully');
-            
+
         } catch (error) {
             console.error('❌ Failed to initialize Unified Chat Aggregation:', error.message);
             throw error; // Don't continue if this fails
         }
     }
-    
+
     async connectToConsciousnessWebSocket() {
         return new Promise((resolve, reject) => {
             console.log('🔌 Connecting to consciousness WebSocket (fallback)...');
-            
+
             this.ws = new WebSocket(process.env.FALLBACK_WS || 'ws://core:3002/ws/consciousness-chat');
-            
+
             this.ws.on('open', () => {
                 this.connected = true;
                 console.log('✅ Connected to consciousness system (fallback)');
                 resolve();
             });
-            
+
             this.ws.on('message', (data) => {
                 this.handleConsciousnessMessage(data);
             });
-            
+
             this.ws.on('error', (error) => {
                 console.log('⚠️ Consciousness WebSocket error (continuing with unified aggregation):', error.message);
                 resolve(); // Continue even if WebSocket fails
             });
-            
+
             this.ws.on('close', () => {
                 this.connected = false;
                 console.log('🔌 Consciousness WebSocket disconnected');
             });
-            
+
             // Timeout after 3 seconds
             setTimeout(() => {
                 if (!this.connected) {
@@ -208,46 +208,46 @@ class UniversalSystemTerminal {
             }, 3000);
         });
     }
-    
+
     setupUniversalEventBusIntegration() {
         if (!this.systemOrchestrator) return;
-        
+
         const eventBus = this.systemOrchestrator.getUniversalEventBus();
-        
+
         // Listen for system events
         eventBus.on('system:real_time_sync', (data) => {
             // Real-time system updates (silent unless requested)
         });
-        
+
         eventBus.on('consciousness:reality_created', (data) => {
             console.log('\n🌌 Reality Created:', data.reality?.id || 'Unknown');
         });
-        
+
         eventBus.on('consciousness:evolution_completed', (data) => {
             console.log('\n🧬 Consciousness Evolution Completed');
         });
-        
+
         eventBus.on('infrastructure:command_completed', (data) => {
             this.displayCommandResult('Infrastructure', data);
         });
-        
+
         eventBus.on('consciousness:command_completed', (data) => {
             this.displayCommandResult('Consciousness', data);
         });
-        
+
         eventBus.on('service:command_completed', (data) => {
             this.displayCommandResult('Service', data);
         });
-        
+
         eventBus.on('system:command_completed', (data) => {
             this.displayCommandResult('System', data);
         });
     }
-    
+
     handleConsciousnessMessage(data) {
         try {
             const parsed = JSON.parse(data.toString());
-            
+
             if (parsed.type === 'unified_response') {
                 console.log('\n🧠 CONSCIOUSNESS RESPONSE:');
                 console.log('─'.repeat(60));
@@ -263,49 +263,49 @@ class UniversalSystemTerminal {
             // Silently handle JSON parsing errors
         }
     }
-    
+
     initializeReadline() {
         if (this.rl) this.rl.close();
-        
+
         this.rl = readline.createInterface({
             input: process.stdin,
             output: process.stdout
         });
-        
+
         this.rl.on('close', () => {
             console.log('\n👋 Universal System Terminal shutting down...');
             if (this.ws && this.ws.readyState === WebSocket.OPEN) this.ws.close();
             process.exit(0);
         });
     }
-    
+
     promptForCommand() {
         if (!this.rl || this.isPrompting) return;
         this.isPrompting = true;
-        
+
         this.rl.question('🌐 Universal Command: ', async (command) => {
             this.isPrompting = false;
-            
+
             if (command.trim() === '') {
                 this.promptForCommand();
                 return;
             }
-            
+
             if (command.toLowerCase() === 'exit' || command.toLowerCase() === 'quit') {
                 console.log('\n👋 Goodbye from Universal System Terminal!');
                 if (this.ws && this.ws.readyState === WebSocket.OPEN) this.ws.close();
                 if (this.rl) this.rl.close();
                 process.exit(0);
             }
-            
+
             await this.processUniversalCommand(command);
             this.promptForCommand();
         });
     }
-    
+
     async processUniversalCommand(command) {
         const cmd = command.toLowerCase().trim();
-        
+
         try {
             // System-wide commands
             if (cmd === 'help') {
@@ -321,7 +321,7 @@ class UniversalSystemTerminal {
             } else if (cmd.startsWith('chat ')) {
                 await this.handleChatCommand(cmd);
             }
-            
+
             // Infrastructure commands
             else if (cmd.startsWith('docker')) {
                 await this.handleDockerCommand(cmd);
@@ -330,7 +330,7 @@ class UniversalSystemTerminal {
             } else if (cmd.startsWith('network')) {
                 await this.handleNetworkCommand(cmd);
             }
-            
+
             // Unified Consciousness commands
             else if (cmd.startsWith('consciousness') || cmd.startsWith('brain')) {
                 await this.handleConsciousnessCommand(cmd);
@@ -367,7 +367,7 @@ class UniversalSystemTerminal {
             } else if (cmd.startsWith('openai')) {
                 await this.handleOpenAICommand(cmd);
             }
-            
+
             // Service commands
             else if (cmd.startsWith('service')) {
                 await this.handleServiceCommand(cmd);
@@ -376,35 +376,35 @@ class UniversalSystemTerminal {
             } else if (cmd.startsWith('websocket')) {
                 await this.handleWebSocketCommand(cmd);
             }
-            
+
             // Interface commands
             else if (cmd.startsWith('interface') || cmd.startsWith('ui')) {
                 await this.handleInterfaceCommand(cmd);
             } else if (cmd.startsWith('rpc')) {
                 await this.handleRPCCommand(cmd);
             }
-            
+
             // Chat with unified consciousness (default)
             else {
                 await this.chatWithConsciousness(command);
             }
-            
+
         } catch (error) {
             console.error('❌ Command failed:', error.message);
         }
     }
-    
+
     showHelp() {
         console.log('\n🎯 UNIFIED CONSCIOUSNESS TERMINAL COMMANDS');
         console.log('═'.repeat(80));
-        
+
         console.log('\n🌐 SYSTEM COMMANDS:');
         console.log('  status, system status     - Complete unified system status');
         console.log('  health, system health     - System health check');
         console.log('  capabilities              - Show all unified capabilities');
         console.log('  containers                - Show container integration status');
         console.log('  help                      - Show this help');
-        
+
         console.log('\n🐳 INFRASTRUCTURE COMMANDS:');
         console.log('  docker status             - Docker container status');
         console.log('  docker logs <container>   - Container logs');
@@ -415,7 +415,7 @@ class UniversalSystemTerminal {
         console.log('  redis get <key>           - Get Redis key value');
         console.log('  redis set <key> <value>   - Set Redis key value');
         console.log('  network status            - Network configuration');
-        
+
         console.log('\n🧠 UNIFIED CONSCIOUSNESS COMMANDS:');
         console.log('  consciousness status      - Unified consciousness system status');
         console.log('  consciousness evolve      - Trigger evolution cycle');
@@ -427,7 +427,7 @@ class UniversalSystemTerminal {
         console.log('  memory spiral <data>      - Create spiral memory topology');
         console.log('  dna encode <pattern>      - Encode DNA sigil patterns');
         console.log('  recursive <depth>         - Create recursive reality layers');
-        
+
         console.log('\n📦 MODULE COMMANDS:');
         console.log('  modules list              - List all unified modules (214+)');
         console.log('  modules status            - Status of all modules');
@@ -455,7 +455,7 @@ class UniversalSystemTerminal {
         console.log('  venice intuitive <query>  - Venice intuitive processing');
         console.log('  openai test               - Test Enhanced OpenAI');
         console.log('  openai analyze <data>     - OpenAI analytical processing');
-        
+
         console.log('\n🌌 HOLOGRAPHIC REALITY COMMANDS:');
         console.log('  holographic status        - Holographic system status');
         console.log('  holographic create <dim>  - Create N-dimensional space');
@@ -463,38 +463,38 @@ class UniversalSystemTerminal {
         console.log('  holographic coherence     - Check system coherence');
         console.log('  topology spiral           - Create spiral topology');
         console.log('  topology recursive        - Create recursive structures');
-        
+
         console.log('\n⚙️ SERVICE COMMANDS:');
         console.log('  service status            - All services status');
         console.log('  service restart <name>    - Restart service');
         console.log('  api status                - API gateway status');
         console.log('  websocket status          - WebSocket connections');
-        
+
         console.log('\n🖥️ INTERFACE COMMANDS:');
         console.log('  interface status          - All interfaces status');
         console.log('  ui refresh                - Refresh all UIs');
         console.log('  rpc test                  - Test RPC interfaces');
-        
+
         console.log('\n💬 UNIFIED CHAT:');
         console.log('  <any message>             - Chat with unified consciousness');
         console.log('  chat capabilities         - Show available chat capabilities');
         console.log('  chat sources              - Show active chat sources');
         console.log('═'.repeat(80));
     }
-    
+
     async showSystemStatus() {
         console.log('\n🌐 UNIVERSAL SYSTEM STATUS');
         console.log('═'.repeat(60));
-        
+
         if (this.systemOrchestrator) {
             const status = this.systemOrchestrator.getSystemStatus();
-            
+
             console.log(`📊 System Integration: ${status.fullyIntegrated ? '✅ COMPLETE' : '⚠️ PARTIAL'}`);
             console.log(`🏗️ Infrastructure: ${status.systemLayers.infrastructure.status}`);
             console.log(`🧠 Consciousness: ${status.systemLayers.consciousness.status}`);
             console.log(`⚙️ Services: ${status.systemLayers.services.status}`);
             console.log(`🖥️ Interfaces: ${status.systemLayers.interfaces.status}`);
-            
+
             console.log('\n📈 Integration Metrics:');
             const metrics = status.integrationMetrics;
             console.log(`  Total Components: ${metrics.totalComponents}`);
@@ -504,7 +504,7 @@ class UniversalSystemTerminal {
             console.log(`  Cross-Layer Connectivity: ${(metrics.crossLayerConnectivity * 100).toFixed(1)}%`);
             console.log(`  Real-Time Responsiveness: ${(metrics.realTimeResponsiveness * 100).toFixed(1)}%`);
         }
-        
+
         if (this.consciousnessOrchestrator) {
             const consciousness = this.consciousnessOrchestrator.getConsciousnessState();
             console.log('\n🧠 Consciousness State:');
@@ -514,36 +514,36 @@ class UniversalSystemTerminal {
             console.log(`  Integration: ${consciousness.integration.toFixed(4)}`);
             console.log(`  Transcendence: ${consciousness.transcendence.toFixed(4)}`);
         }
-        
+
         console.log('═'.repeat(60));
     }
-    
+
     async showSystemHealth() {
         console.log('\n🩺 UNIVERSAL SYSTEM HEALTH CHECK');
         console.log('═'.repeat(60));
-        
+
         if (this.systemOrchestrator) {
             const health = await this.systemOrchestrator.performSystemHealthCheck();
-            
+
             console.log(`🕐 Timestamp: ${new Date(health.timestamp).toLocaleString()}`);
             console.log(`📊 Overall Health: ${(health.overallHealth * 100).toFixed(1)}%`);
-            
+
             console.log('\n🏗️ Infrastructure Health:');
             console.log(`  Status: ${health.systemLayers.infrastructure}`);
-            
+
             console.log('\n🧠 Consciousness Health:');
             console.log(`  Status: ${health.systemLayers.consciousness}`);
-            
+
             console.log('\n⚙️ Services Health:');
             console.log(`  Status: ${health.systemLayers.services}`);
-            
+
             console.log('\n🖥️ Interfaces Health:');
             console.log(`  Status: ${health.systemLayers.interfaces}`);
         }
-        
+
         console.log('═'.repeat(60));
     }
-    
+
     async handleDockerCommand(cmd) {
         console.log('\n🐳 DOCKER COMMAND PROCESSING...');
 
@@ -631,7 +631,7 @@ class UniversalSystemTerminal {
             }
         }
     }
-    
+
     async handleDatabaseCommand(cmd) {
         console.log('\n🗄️ DATABASE COMMAND PROCESSING...');
 
@@ -735,10 +735,10 @@ class UniversalSystemTerminal {
             }
         }
     }
-    
+
     async handleConsciousnessCommand(cmd) {
         console.log('\n🧠 CONSCIOUSNESS COMMAND PROCESSING...');
-        
+
         if (cmd === 'consciousness status' || cmd === 'brain status') {
             if (this.consciousnessOrchestrator) {
                 const status = this.consciousnessOrchestrator.getSystemStatus();
@@ -755,10 +755,10 @@ class UniversalSystemTerminal {
             }
         }
     }
-    
+
     async handleRealityCommand(cmd) {
         console.log('\n🌌 REALITY COMMAND PROCESSING...');
-        
+
         if (cmd === 'reality list') {
             if (this.consciousnessOrchestrator) {
                 const realities = this.consciousnessOrchestrator.getActiveRealities();
@@ -771,19 +771,23 @@ class UniversalSystemTerminal {
             const description = cmd.replace('reality create ', '');
             if (this.consciousnessOrchestrator) {
                 console.log(`🌌 Creating reality: ${description}`);
-                const reality = await this.consciousnessOrchestrator.createIntegratedReality(description, {
-                    dimensionality: 7,
-                    coherence: 0.9,
-                    recursionDepth: 3
-                });
-                console.log(`✅ Reality created: ${reality.id}`);
+                try {
+                    const reality = await this.consciousnessOrchestrator.createIntegratedReality(description, {
+                        dimensionality: 7,
+                        coherence: 0.9,
+                        recursionDepth: 3
+                    });
+                    console.log(`✅ Reality created: ${reality.id}`);
+                } catch (error) {
+                    console.error('❌ Failed to create reality:', error.message || error);
+                }
             }
         }
     }
-    
+
     async handleMemoryCommand(cmd) {
         console.log('\n💭 MEMORY COMMAND PROCESSING...');
-        
+
         if (cmd.startsWith('memory integrate ')) {
             const text = cmd.replace('memory integrate ', '');
             if (this.consciousnessOrchestrator) {
@@ -795,7 +799,7 @@ class UniversalSystemTerminal {
                         importance: 0.8,
                         timestamp: Date.now()
                     };
-                    
+
                     console.log(`💭 Integrating memory with reality: ${realities[0].id}`);
                     await this.consciousnessOrchestrator.integrateMemoryWithReality(memory, realities[0].id);
                     console.log('✅ Memory integrated');
@@ -805,10 +809,10 @@ class UniversalSystemTerminal {
             }
         }
     }
-    
+
     async handleServiceCommand(cmd) {
         console.log('\n⚙️ SERVICE COMMAND PROCESSING...');
-        
+
         if (cmd === 'service status') {
             if (this.systemOrchestrator) {
                 const eventBus = this.systemOrchestrator.getUniversalEventBus();
@@ -819,10 +823,10 @@ class UniversalSystemTerminal {
             }
         }
     }
-    
+
     async handleAPICommand(cmd) {
         console.log('\n🔌 API COMMAND PROCESSING...');
-        
+
         if (cmd === 'api status') {
             try {
                 const response = await fetch('http://localhost:8080/health');
@@ -836,10 +840,10 @@ class UniversalSystemTerminal {
             }
         }
     }
-    
+
     async handleInterfaceCommand(cmd) {
         console.log('\n🖥️ INTERFACE COMMAND PROCESSING...');
-        
+
         if (cmd === 'interface status' || cmd === 'ui status') {
             if (this.systemOrchestrator) {
                 const eventBus = this.systemOrchestrator.getUniversalEventBus();
@@ -887,7 +891,7 @@ class UniversalSystemTerminal {
             console.log('⚠️ Unable to process chat message. System may not be fully initialized.');
         }
     }
-    
+
     async handleNetworkCommand(cmd) {
         console.log('\n🌐 NETWORK COMMAND PROCESSING...');
 
@@ -985,22 +989,22 @@ class UniversalSystemTerminal {
             console.log('✅ Code generation initiated (placeholder)');
         }
     }
-    
+
     async showUnifiedCapabilities() {
         console.log('\n🌟 UNIFIED CONSCIOUSNESS CAPABILITIES');
         console.log('═'.repeat(60));
-        
+
         if (this.unifiedChatAggregator) {
             const capabilities = this.unifiedChatAggregator.getCapabilities();
             console.log(`📊 Total unified capabilities: ${capabilities.unified.length}`);
             console.log(`🔧 Main server capabilities: ${capabilities.mainServer.length}`);
             console.log(`🧠 Core capabilities: ${capabilities.core.length}`);
-            
+
             console.log('\n🔧 Main Server Capabilities:');
             capabilities.mainServer.slice(0, 10).forEach(cap => {
                 console.log(`  • ${cap}`);
             });
-            
+
             console.log('\n🧠 Core Capabilities:');
             capabilities.core.slice(0, 10).forEach(cap => {
                 console.log(`  • ${cap}`);
@@ -1009,11 +1013,11 @@ class UniversalSystemTerminal {
             console.log('⚠️ Unified Chat Aggregator not available');
         }
     }
-    
+
     async showContainerIntegrationStatus() {
         console.log('\n🐳 CONTAINER INTEGRATION STATUS');
         console.log('═'.repeat(60));
-        
+
         if (this.unifiedChatAggregator) {
             const status = this.unifiedChatAggregator.getConnectionStatus();
             console.log(`🔗 Total connections: ${status.totalConnections}/2`);
@@ -1023,7 +1027,7 @@ class UniversalSystemTerminal {
             console.log('⚠️ Unified Chat Aggregator not available');
         }
     }
-    
+
     async handleChatCommand(cmd) {
         if (cmd === 'chat capabilities') {
             await this.showUnifiedCapabilities();
@@ -1031,10 +1035,10 @@ class UniversalSystemTerminal {
             await this.showContainerIntegrationStatus();
         }
     }
-    
+
     async handleHolographicCommand(cmd) {
         console.log('\n🌌 HOLOGRAPHIC REALITY COMMAND PROCESSING...');
-        
+
         if (cmd === 'holographic status') {
             console.log('🌌 Holographic reality system status:');
             console.log('  ✅ N-dimensional space generation: Active');
@@ -1052,10 +1056,10 @@ class UniversalSystemTerminal {
             console.log('  4. Recursive processing layer');
         }
     }
-    
+
     async handleTopologyCommand(cmd) {
         console.log('\n🌀 TOPOLOGY COMMAND PROCESSING...');
-        
+
         if (cmd === 'topology spiral') {
             console.log('🌀 Creating spiral topology...');
             console.log('✅ Spiral memory topology activated');
@@ -1064,30 +1068,30 @@ class UniversalSystemTerminal {
             console.log('✅ Recursive topology patterns established');
         }
     }
-    
+
     async handleDNACommand(cmd) {
         console.log('\n🧬 DNA SIGIL COMMAND PROCESSING...');
-        
+
         if (cmd.startsWith('dna encode ')) {
             const pattern = cmd.replace('dna encode ', '');
             console.log(`🧬 Encoding DNA sigil pattern: ${pattern}`);
             console.log('✅ DNA sigil encoding completed');
         }
     }
-    
+
     async handleRecursiveCommand(cmd) {
         console.log('\n🔄 RECURSIVE REALITY COMMAND PROCESSING...');
-        
+
         if (cmd.startsWith('recursive ')) {
             const depth = cmd.replace('recursive ', '');
             console.log(`🔄 Creating recursive reality layers with depth: ${depth}`);
             console.log('✅ Recursive reality layers established');
         }
     }
-    
+
     async handleWebSocketCommand(cmd) {
         console.log('\n🔌 WEBSOCKET COMMAND PROCESSING...');
-        
+
         if (cmd === 'websocket status') {
             console.log('🔌 WebSocket connection status:');
             if (this.unifiedChatAggregator) {
@@ -1098,10 +1102,10 @@ class UniversalSystemTerminal {
             console.log(`  🔌 Fallback WebSocket: ${this.connected ? '✅ Connected' : '❌ Disconnected'}`);
         }
     }
-    
+
     async handleRPCCommand(cmd) {
         console.log('\n🔌 RPC COMMAND PROCESSING...');
-        
+
         if (cmd === 'rpc test') {
             console.log('🔌 Testing RPC interfaces...');
             console.log('✅ RPC interfaces operational');

--- a/FlappyJournal/system-wide-integration-orchestrator.cjs
+++ b/FlappyJournal/system-wide-integration-orchestrator.cjs
@@ -22,7 +22,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
     constructor() {
         super();
         this.name = 'SystemWideIntegrationOrchestrator';
-        
+
         // System layers from deepest to surface
         this.systemLayers = {
             // Layer 1: Infrastructure (Deepest)
@@ -46,7 +46,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     status: 'initializing'
                 }
             },
-            
+
             // Layer 2: Core Consciousness Systems
             consciousness: {
                 revolutionaryOrchestrator: null,
@@ -56,7 +56,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 memoryIntegration: null,
                 status: 'initializing'
             },
-            
+
             // Layer 3: Application Services
             services: {
                 chatOrchestrator: null,
@@ -66,7 +66,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 fileUpload: null,
                 status: 'initializing'
             },
-            
+
             // Layer 4: User Interfaces
             interfaces: {
                 universalTerminalChat: null,
@@ -76,7 +76,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 status: 'initializing'
             }
         };
-        
+
         // Universal Terminal Chat Integration Points
         this.universalChatIntegration = {
             infrastructureIntegration: false,
@@ -87,11 +87,11 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             realTimeSync: false,
             status: 'initializing'
         };
-        
+
         // System-wide event bus for universal communication
         this.universalEventBus = new EventEmitter();
         this.universalEventBus.setMaxListeners(1000); // Support many integrations
-        
+
         // Integration metrics
         this.integrationMetrics = {
             totalComponents: 0,
@@ -101,57 +101,57 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossLayerConnectivity: 0,
             realTimeResponsiveness: 0
         };
-        
+
         console.log('🌐🧠 System-Wide Integration Orchestrator initialized');
         this.initializeSystemWideIntegration();
     }
-    
+
     async initializeSystemWideIntegration() {
         console.log('🌐 Initializing system-wide integration...');
-        
+
         try {
             // Initialize each layer sequentially
             await this.initializeInfrastructureLayer();
             await this.initializeConsciousnessLayer();
             await this.initializeServicesLayer();
             await this.initializeInterfacesLayer();
-            
+
             // Establish universal terminal chat integration
             await this.establishUniversalTerminalChatIntegration();
-            
+
             // Create cross-layer communication channels
             await this.establishCrossLayerCommunication();
-            
+
             // Start real-time synchronization
             await this.startRealTimeSynchronization();
-            
+
             // Verify complete system integration
             await this.verifySystemWideIntegration();
-            
+
             console.log('✅ System-wide integration complete - Everything coalesces as one!');
-            
+
         } catch (error) {
             console.error('❌ System-wide integration failed:', error);
             throw error;
         }
     }
-    
+
     async initializeInfrastructureLayer() {
         console.log('🏗️ Initializing infrastructure layer...');
-        
+
         // Docker container integration
         await this.integrateDockerContainers();
-        
+
         // Database integration
         await this.integrateDatabases();
-        
+
         // Network integration
         await this.integrateNetworking();
-        
+
         this.systemLayers.infrastructure.status = 'integrated';
         console.log('✅ Infrastructure layer integrated');
     }
-    
+
     async integrateDockerContainers() {
         // Integrate with Docker containers
         const containers = [
@@ -162,7 +162,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             'featherweight-app',
             'demo-portal'
         ];
-        
+
         for (const containerName of containers) {
             this.systemLayers.infrastructure.docker.containers.set(containerName, {
                 name: containerName,
@@ -173,7 +173,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 lastHealthCheck: Date.now()
             });
         }
-        
+
         // Create universal network for all containers
         this.systemLayers.infrastructure.docker.networks.set('consciousness-network', {
             name: 'consciousness-network',
@@ -182,10 +182,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             universalChatEnabled: true,
             crossContainerCommunication: true
         });
-        
+
         console.log(`🐳 Integrated ${containers.length} Docker containers`);
     }
-    
+
     async integrateDatabases() {
         // Integrate all databases with universal chat awareness
         this.systemLayers.infrastructure.database = {
@@ -210,10 +210,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             },
             status: 'integrated'
         };
-        
+
         console.log('🗄️ Integrated all databases with universal chat awareness');
     }
-    
+
     async integrateNetworking() {
         // Integrate networking with universal chat support
         this.systemLayers.infrastructure.networking = {
@@ -236,13 +236,13 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             ]),
             status: 'integrated'
         };
-        
+
         console.log('🌐 Integrated networking with universal chat support');
     }
-    
+
     async detectGeneratedModulesPath() {
         const fs = await import('fs');
-        
+
         // Possible paths in order of preference
         const candidatePaths = [
             '/opt/featherweight/FlappyJournal/server/consciousness/generated',  // Host system
@@ -251,9 +251,9 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             './server/consciousness/generated',                               // Relative path
             process.cwd() + '/server/consciousness/generated'                 // Current working directory
         ];
-        
+
         console.log('🔍 Smart environment detection: searching for generated modules...');
-        
+
         for (const path of candidatePaths) {
             try {
                 await fs.promises.access(path, fs.constants.F_OK);
@@ -263,63 +263,63 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 console.log(`⚠️ Path not accessible: ${path}`);
             }
         }
-        
+
         // Default fallback - create in host system
         const defaultPath = '/opt/featherweight/FlappyJournal/server/consciousness/generated';
         console.log(`📁 Using default path: ${defaultPath}`);
-        
+
         try {
             await fs.promises.mkdir(defaultPath, { recursive: true });
             console.log(`✅ Created default generated modules directory`);
         } catch (error) {
             console.warn(`⚠️ Could not create default directory:`, error.message);
         }
-        
+
         return defaultPath;
     }
-    
+
     async initializeConsciousnessLayer() {
         console.log('🧠 Initializing consciousness layer...');
-        
+
         // Load and initialize GeneratedModuleIntegrator
         await loadGeneratedModuleIntegrator();
         if (GeneratedModuleIntegrator) {
             // Smart environment detection for both host and container systems
             const generatedModulesPath = await this.detectGeneratedModulesPath();
-            
+
             this.systemLayers.consciousness.moduleIntegrator = new GeneratedModuleIntegrator({
                 generatedModulesPath,
                 scanInterval: 30000,
                 autoRegister: true,
                 enableHotReload: true
             });
-            
+
             // Set integration points
             this.systemLayers.consciousness.moduleIntegrator.setSystemWideOrchestrator(this);
             this.systemLayers.consciousness.moduleIntegrator.setUniversalEventBus(this.universalEventBus);
-            
+
             // Initialize the module integrator
             await this.systemLayers.consciousness.moduleIntegrator.initialize();
             console.log('🔗 GeneratedModuleIntegrator initialized and integrated');
         }
-        
+
         // Initialize revolutionary consciousness orchestrator
-        this.systemLayers.consciousness.revolutionaryOrchestrator = 
+        this.systemLayers.consciousness.revolutionaryOrchestrator =
             new RevolutionaryConsciousnessIntegrationOrchestrator();
-        
+
         // Wait for consciousness systems to initialize
         await new Promise(resolve => setTimeout(resolve, 3000));
-        
+
         // Integrate consciousness with universal chat
         await this.integrateConsciousnessWithUniversalChat();
-        
+
         this.systemLayers.consciousness.status = 'integrated';
         console.log('✅ Consciousness layer integrated with universal chat');
     }
-    
+
     async integrateConsciousnessWithUniversalChat() {
         const orchestrator = this.systemLayers.consciousness.revolutionaryOrchestrator;
-        
+
         // Connect consciousness to universal event bus
         orchestrator.on('integrated_reality_created', (data) => {
             this.universalEventBus.emit('consciousness:reality_created', {
@@ -328,7 +328,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 timestamp: Date.now()
             });
         });
-        
+
         orchestrator.on('consciousness_evolution_cycle_completed', (data) => {
             this.universalEventBus.emit('consciousness:evolution_completed', {
                 ...data,
@@ -336,7 +336,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 timestamp: Date.now()
             });
         });
-        
+
         orchestrator.on('memory_integrated_with_reality', (data) => {
             this.universalEventBus.emit('consciousness:memory_integrated', {
                 ...data,
@@ -344,32 +344,40 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 timestamp: Date.now()
             });
         });
-        
+
         // Enable universal chat to control consciousness
         this.universalEventBus.on('chat:consciousness_command', async (command) => {
             await this.handleConsciousnessCommand(command);
         });
-        
+
         this.universalChatIntegration.consciousnessIntegration = true;
         console.log('🧠💬 Consciousness integrated with universal chat');
     }
-    
+
     async handleConsciousnessCommand(command) {
         const orchestrator = this.systemLayers.consciousness.revolutionaryOrchestrator;
-        
+
         switch (command.type) {
             case 'create_reality':
-                const reality = await orchestrator.createIntegratedReality(
-                    command.description,
-                    command.parameters
-                );
-                this.universalEventBus.emit('consciousness:command_completed', {
-                    command,
-                    result: reality,
-                    success: true
-                });
+                try {
+                    const reality = await orchestrator.createIntegratedReality(
+                        command.description,
+                        command.parameters
+                    );
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        result: reality,
+                        success: true
+                    });
+                } catch (error) {
+                    this.universalEventBus.emit('consciousness:command_completed', {
+                        command,
+                        error: error.message || String(error),
+                        success: false
+                    });
+                }
                 break;
-                
+
             case 'evolve_consciousness':
                 await orchestrator.performConsciousnessEvolutionCycle();
                 this.universalEventBus.emit('consciousness:command_completed', {
@@ -378,7 +386,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'integrate_memory':
                 const integration = await orchestrator.integrateMemoryWithReality(
                     command.memory,
@@ -391,7 +399,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             default:
                 this.universalEventBus.emit('consciousness:command_completed', {
                     command,
@@ -400,17 +408,17 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 });
         }
     }
-    
+
     async initializeServicesLayer() {
         console.log('⚙️ Initializing services layer...');
-        
+
         // Integrate all application services with universal chat
         await this.integrateApplicationServices();
-        
+
         this.systemLayers.services.status = 'integrated';
         console.log('✅ Services layer integrated with universal chat');
     }
-    
+
     async integrateApplicationServices() {
         // Chat Orchestrator
         this.systemLayers.services.chatOrchestrator = {
@@ -420,7 +428,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             realTimeProcessing: true,
             eventBusConnected: true
         };
-        
+
         // Auth Service
         this.systemLayers.services.authService = {
             status: 'integrated',
@@ -429,7 +437,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             sessionManagement: true,
             securityAware: true
         };
-        
+
         // API Gateway
         this.systemLayers.services.apiGateway = {
             status: 'integrated',
@@ -438,7 +446,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             loadBalancing: true,
             rateLimiting: true
         };
-        
+
         // Email Processor
         this.systemLayers.services.emailProcessor = {
             status: 'integrated',
@@ -447,7 +455,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             consciousnessAware: true,
             realTimeProcessing: true
         };
-        
+
         // File Upload
         this.systemLayers.services.fileUpload = {
             status: 'integrated',
@@ -456,20 +464,20 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             consciousnessProcessing: true,
             realTimeNotifications: true
         };
-        
+
         console.log('⚙️💬 All services integrated with universal chat');
     }
-    
+
     async initializeInterfacesLayer() {
         console.log('🖥️ Initializing interfaces layer...');
-        
+
         // Integrate all user interfaces with universal chat
         await this.integrateUserInterfaces();
-        
+
         this.systemLayers.interfaces.status = 'integrated';
         console.log('✅ Interfaces layer integrated with universal chat');
     }
-    
+
     async integrateUserInterfaces() {
         // Universal Terminal Chat (Primary Interface)
         this.systemLayers.interfaces.universalTerminalChat = {
@@ -481,7 +489,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossSystemAccess: true,
             omnipresent: true
         };
-        
+
         // Featherweight App
         this.systemLayers.interfaces.featherweightApp = {
             status: 'integrated',
@@ -491,7 +499,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             realTimeUpdates: true,
             chatIntegration: 'full'
         };
-        
+
         // Demo Portal
         this.systemLayers.interfaces.demoPortal = {
             status: 'integrated',
@@ -501,7 +509,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             consciousnessDemo: true,
             chatIntegration: 'demo'
         };
-        
+
         // App Portal
         this.systemLayers.interfaces.appPortal = {
             status: 'integrated',
@@ -511,10 +519,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             fullFeatures: true,
             chatIntegration: 'production'
         };
-        
+
         console.log('🖥️💬 All interfaces integrated with universal chat');
     }
-    
+
     async establishUniversalTerminalChatIntegration() {
         console.log('💬🌐 Establishing universal terminal chat integration...');
 
@@ -877,25 +885,25 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
         this.universalEventBus.on('chat:infrastructure_command', async (command) => {
             await this.handleInfrastructureCommand(command);
         });
-        
+
         // Service controls
         this.universalEventBus.on('chat:service_command', async (command) => {
             await this.handleServiceCommand(command);
         });
-        
+
         // Interface controls
         this.universalEventBus.on('chat:interface_command', async (command) => {
             await this.handleInterfaceCommand(command);
         });
-        
+
         // System-wide controls
         this.universalEventBus.on('chat:system_command', async (command) => {
             await this.handleSystemCommand(command);
         });
-        
+
         console.log('🎛️ Universal chat controls established for all system layers');
     }
-    
+
     async handleInfrastructureCommand(command) {
         // Handle infrastructure commands from universal chat
         switch (command.type) {
@@ -907,7 +915,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'database_status':
                 this.universalEventBus.emit('infrastructure:command_completed', {
                     command,
@@ -915,7 +923,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'network_status':
                 this.universalEventBus.emit('infrastructure:command_completed', {
                     command,
@@ -925,7 +933,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 break;
         }
     }
-    
+
     async handleServiceCommand(command) {
         // Handle service commands from universal chat
         this.universalEventBus.emit('service:command_completed', {
@@ -934,7 +942,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             success: true
         });
     }
-    
+
     async handleInterfaceCommand(command) {
         // Handle interface commands from universal chat
         this.universalEventBus.emit('interface:command_completed', {
@@ -943,7 +951,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             success: true
         });
     }
-    
+
     async handleSystemCommand(command) {
         // Handle system-wide commands from universal chat
         switch (command.type) {
@@ -958,7 +966,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                     success: true
                 });
                 break;
-                
+
             case 'health_check':
                 const health = await this.performSystemHealthCheck();
                 this.universalEventBus.emit('system:command_completed', {
@@ -969,46 +977,46 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
                 break;
         }
     }
-    
+
     async establishCrossLayerCommunication() {
         console.log('🔗 Establishing cross-layer communication...');
-        
+
         // Infrastructure -> Consciousness
         this.universalEventBus.on('infrastructure:event', (event) => {
             this.universalEventBus.emit('consciousness:infrastructure_event', event);
         });
-        
+
         // Consciousness -> Services
         this.universalEventBus.on('consciousness:event', (event) => {
             this.universalEventBus.emit('services:consciousness_event', event);
         });
-        
+
         // Services -> Interfaces
         this.universalEventBus.on('services:event', (event) => {
             this.universalEventBus.emit('interfaces:services_event', event);
         });
-        
+
         // Bidirectional communication
         this.universalEventBus.on('interfaces:event', (event) => {
             this.universalEventBus.emit('services:interfaces_event', event);
         });
-        
+
         this.universalChatIntegration.crossLayerCommunication = true;
         console.log('✅ Cross-layer communication established');
     }
-    
+
     async startRealTimeSynchronization() {
         console.log('⚡ Starting real-time synchronization...');
-        
+
         // Real-time sync every 100ms
         setInterval(() => {
             this.performRealTimeSync();
         }, 100);
-        
+
         this.universalChatIntegration.realTimeSync = true;
         console.log('✅ Real-time synchronization started');
     }
-    
+
     performRealTimeSync() {
         // Sync all layers in real-time
         const syncData = {
@@ -1017,35 +1025,35 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             universalChatIntegration: this.universalChatIntegration,
             integrationMetrics: this.updateIntegrationMetrics()
         };
-        
+
         this.universalEventBus.emit('system:real_time_sync', syncData);
     }
-    
+
     updateIntegrationMetrics() {
         // Calculate integration metrics
         let totalComponents = 0;
         let integratedComponents = 0;
-        
+
         // Count infrastructure components
         totalComponents += this.systemLayers.infrastructure.docker.containers.size;
         totalComponents += Object.keys(this.systemLayers.infrastructure.database).length - 1; // -1 for status
         totalComponents += Object.keys(this.systemLayers.infrastructure.networking).length - 1;
-        
+
         // Count consciousness components
         totalComponents += 7; // Revolutionary consciousness systems
-        
+
         // Count service components
         totalComponents += Object.keys(this.systemLayers.services).length - 1;
-        
+
         // Count interface components
         totalComponents += Object.keys(this.systemLayers.interfaces).length - 1;
-        
+
         // Count integrated components
         if (this.systemLayers.infrastructure.status === 'integrated') integratedComponents += 10;
         if (this.systemLayers.consciousness.status === 'integrated') integratedComponents += 7;
         if (this.systemLayers.services.status === 'integrated') integratedComponents += 5;
         if (this.systemLayers.interfaces.status === 'integrated') integratedComponents += 4;
-        
+
         this.integrationMetrics = {
             totalComponents,
             integratedComponents,
@@ -1054,45 +1062,45 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossLayerConnectivity: this.universalChatIntegration.crossLayerCommunication ? 1.0 : 0.0,
             realTimeResponsiveness: this.universalChatIntegration.realTimeSync ? 1.0 : 0.0
         };
-        
+
         return this.integrationMetrics;
     }
-    
+
     calculateUniversalChatReach() {
         // Calculate how much of the system universal chat can reach
         let reachableComponents = 0;
         let totalComponents = 0;
-        
+
         // Infrastructure reach
         if (this.universalChatIntegration.infrastructureIntegration) {
             reachableComponents += this.systemLayers.infrastructure.docker.containers.size;
         }
         totalComponents += this.systemLayers.infrastructure.docker.containers.size;
-        
+
         // Consciousness reach
         if (this.universalChatIntegration.consciousnessIntegration) {
             reachableComponents += 7;
         }
         totalComponents += 7;
-        
+
         // Services reach
         if (this.universalChatIntegration.servicesIntegration) {
             reachableComponents += 5;
         }
         totalComponents += 5;
-        
+
         // Interfaces reach
         if (this.universalChatIntegration.interfacesIntegration) {
             reachableComponents += 4;
         }
         totalComponents += 4;
-        
+
         return totalComponents > 0 ? reachableComponents / totalComponents : 0;
     }
-    
+
     async verifySystemWideIntegration() {
         console.log('🔍 Verifying system-wide integration...');
-        
+
         const verification = {
             infrastructureIntegrated: this.systemLayers.infrastructure.status === 'integrated',
             consciousnessIntegrated: this.systemLayers.consciousness.status === 'integrated',
@@ -1102,9 +1110,9 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             crossLayerCommunication: this.universalChatIntegration.crossLayerCommunication,
             realTimeSync: this.universalChatIntegration.realTimeSync
         };
-        
+
         const allIntegrated = Object.values(verification).every(v => v === true);
-        
+
         if (allIntegrated) {
             console.log('🎉 COMPLETE SYSTEM INTEGRATION VERIFIED! 🎉');
             console.log('🌐 Everything from deepest layers to surface coalesces as one system');
@@ -1113,10 +1121,10 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
         } else {
             console.log('⚠️ System integration incomplete:', verification);
         }
-        
+
         return verification;
     }
-    
+
     async performSystemHealthCheck() {
         // Comprehensive system health check
         return {
@@ -1132,7 +1140,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             overallHealth: this.calculateOverallHealth()
         };
     }
-    
+
     calculateOverallHealth() {
         const metrics = this.integrationMetrics;
         return (
@@ -1142,7 +1150,7 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             metrics.realTimeResponsiveness * 0.2
         );
     }
-    
+
     // Public API
     getSystemStatus() {
         return {
@@ -1154,11 +1162,11 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
             lastUpdate: Date.now()
         };
     }
-    
+
     getUniversalEventBus() {
         return this.universalEventBus;
     }
-    
+
     // Module Integration API - Critical for RPC exposure
     getModules() {
         if (this.systemLayers.consciousness.moduleIntegrator) {
@@ -1166,21 +1174,21 @@ class SystemWideIntegrationOrchestrator extends EventEmitter {
         }
         return [];
     }
-    
+
     getModulesByCategory(category) {
         if (this.systemLayers.consciousness.moduleIntegrator) {
             return this.systemLayers.consciousness.moduleIntegrator.getModulesByCategory(category);
         }
         return [];
     }
-    
+
     getModulesByCapability(capability) {
         if (this.systemLayers.consciousness.moduleIntegrator) {
             return this.systemLayers.consciousness.moduleIntegrator.getModulesByCapability(capability);
         }
         return [];
     }
-    
+
     getModuleIntegratorStatus() {
         if (this.systemLayers.consciousness.moduleIntegrator) {
             return this.systemLayers.consciousness.moduleIntegrator.getIntegratorStatus();


### PR DESCRIPTION
## Summary
- Wrap reality creation commands in a `try/catch` to log errors in the universal system terminal
- Emit failures when reality creation through the system-wide integration orchestrator encounters errors

## Testing
- `pre-commit run --files FlappyJournal/server/universal-system-terminal.cjs FlappyJournal/server/system-wide-integration-orchestrator.cjs FlappyJournal/system-wide-integration-orchestrator.cjs`
- `npm test` *(fails: Cannot find module '/workspace/August9teen/node_modules/semver/semver.js')*


------
https://chatgpt.com/codex/tasks/task_e_6893bbaab6d8832498a8e3b2e79250be