### PR TITLE
feat: add parameterized db query support

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -672,13 +672,40 @@ class UniversalSystemTerminal {
                 console.error('❌ Database status failed:', error.message);
             }
         } else if (cmd.startsWith('db query ')) {
-            const sql = cmd.replace('db query ', '');
+            const raw = cmd.replace('db query ', '').trim();
+            const [sqlPart, paramsPart] = raw.split('|').map(s => s.trim());
+            const sql = sqlPart;
+            let params = [];
+
+            if (!sql) {
+                console.log('⚠️ No SQL provided');
+                return;
+            }
+
+            // Only allow read-only queries for safety
+            if (!sql.toLowerCase().startsWith('select')) {
+                console.log('⚠️ Only SELECT queries are allowed');
+                return;
+            }
+
+            if (paramsPart) {
+                try {
+                    params = JSON.parse(paramsPart);
+                    if (!Array.isArray(params)) {
+                        params = [params];
+                    }
+                } catch (parseErr) {
+                    console.log('⚠️ Invalid parameters. Use JSON array after |');
+                    return;
+                }
+            }
+
             try {
                 if (this.systemOrchestrator) {
                     const dbAccess = this.systemOrchestrator.getDeepSystemAccess()?.databaseConnections;
                     if (dbAccess?.postgres) {
                         console.log(`🔍 Executing PostgreSQL query: ${sql}`);
-                        const result = await dbAccess.postgres.query(sql);
+                        const result = await dbAccess.postgres.query(sql, params);
                         console.log(`✅ Query executed. Rows returned: ${result.rowCount || 0}`);
                         if (result.rows && result.rows.length > 0) {
                             console.log('📋 Results:');


### PR DESCRIPTION
## Summary
- validate `db query` commands and enforce read-only SELECT statements
- add JSON-parameter parsing and pass params to PostgreSQL queries

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*
- `npm run lint` *(fails: no-restricted-syntax errors)*
- `npm run type-check` *(fails: TS1068, TS1005)*

------
https://chatgpt.com/codex/tasks/task_e_6893bba2a04c83249d1cd63d19986eed