### PR TITLE
feat: add docker stats fallback

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -624,8 +624,12 @@ class UniversalSystemTerminal {
                         return;
                     }
                 }
-
-                console.log('⚠️ Deep system access not available for stats');
+                // Fallback to direct Docker command when deep access is unavailable
+                const { stdout } = await execAsync(
+                    `docker stats --no-stream --format "CPU: {{.CPUPerc}}\nMemory: {{.MemPerc}}\nNetIO: {{.NetIO}}" ${container}`
+                );
+                console.log(`📊 Stats for ${container}:`);
+                console.log(stdout.trim());
             } catch (error) {
                 console.error('❌ Docker stats failed:', error.message);
             }


### PR DESCRIPTION
## Summary
- add shell fallback when deep access missing for docker stats command

## Testing
- `npm test` *(fails: Parameter 'key' implicitly has an 'any' type, among others)*

------
https://chatgpt.com/codex/tasks/task_e_6893bb99b42c83249cf0a06f13727ad5