### PR TITLE
Utilize chat buffer for post processing

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -78,6 +78,7 @@ class UniversalSystemTerminal {
         this.rl = null;
         this.connected = false;
         this.isPrompting = false;
+        this.lastChatResponse = "";
         
         console.log('🌐🧠🐳🗄️ UNIVERSAL SYSTEM TERMINAL');
         console.log('═'.repeat(80));
@@ -874,6 +875,10 @@ class UniversalSystemTerminal {
                 }
             );
             process.stdout.write('\n');
+            this.lastChatResponse = buffer.trim();
+            if (this.lastChatResponse) {
+                console.log('🧠 Post-processed response captured');
+            }
             console.log('─'.repeat(60));
             if (streamingResult.sources && streamingResult.sources.length > 0) {
                 console.log("🛰️ Sources: " + streamingResult.sources.join(', '));


### PR DESCRIPTION
## Summary
- capture final unified chat response in `lastChatResponse`
- log when a post-processed response is available after streaming

## Testing
- `npm test` *(fails: [BABEL]: Cannot find module '/workspace/August9teen/node_modules/semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6893bb7119988324966bd32e77a1e35c