### PR TITLE
chore: guard event bus in terminal integration

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -211,9 +211,13 @@ class UniversalSystemTerminal {
     
     setupUniversalEventBusIntegration() {
         if (!this.systemOrchestrator) return;
-        
+
         const eventBus = this.systemOrchestrator.getUniversalEventBus();
-        
+        if (!eventBus) {
+            console.log('⚠️ Universal event bus unavailable');
+            return;
+        }
+
         // Listen for system events
         eventBus.on('system:real_time_sync', (data) => {
             // Real-time system updates (silent unless requested)


### PR DESCRIPTION
## Summary
- handle missing event bus before registering listeners in universal system terminal

## Testing
- `npm test` (fails: Cannot find module 'semver' and other missing deps)
- `npm run lint` (fails: Use 'import' instead of 'require' in JS tests)


------
https://chatgpt.com/codex/tasks/task_e_6893bb27c0908324995c780265f05633