### PR TITLE
Initialize CompleteUniversalSystemIntegration in terminal

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -115,7 +115,15 @@ class UniversalSystemTerminal {
             } catch (error) {
                 console.warn('⚠️ Consciousness orchestrator initialization failed:', error.message);
             }
-            
+
+            // Initialize complete universal system integration
+            try {
+                this.completeIntegration = new CompleteUniversalSystemIntegration();
+                console.log('✅ Complete universal integration initialized');
+            } catch (error) {
+                console.warn('⚠️ Complete universal integration initialization failed:', error.message);
+            }
+
             // Initialize unified chat aggregation for multi-container access
             await this.initializeUnifiedChatAggregation();
             


### PR DESCRIPTION
## Summary
- Instantiate CompleteUniversalSystemIntegration within the universal system terminal initialization

## Testing
- `npm test` *(fails: Cannot find module 'semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6893bb11db748324b5e487a250286176