### PR TITLE
Ensure integration is initialized for RPC status

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -45,6 +45,10 @@ if (argvArgs.includes('--rpc') && argvArgs[argvArgs.indexOf('--rpc') + 1] === 'g
         try {
             // Initialise minimal integration context
             const integration = new CompleteUniversalSystemIntegration();
+            // Ensure integration fully initializes before status check
+            if (typeof integration.initialize === 'function') {
+                await integration.initialize();
+            }
             // Allow subsystems to bootstrap (shorter than full 10s terminal wait)
             // give subsystems more time to register modules
             await new Promise(r => setTimeout(r, 10000));


### PR DESCRIPTION
## Summary
- initialize the CompleteUniversalSystemIntegration before collecting status in the RPC quick-exit flow

## Testing
- `npm test -- --runTestsByPath FlappyJournal/server/consciousness/__tests__/autoRollback.test.js` *(fails: Cannot find module 'semver')*


------
https://chatgpt.com/codex/tasks/task_e_6893bb0e13148324bdd6202312f1c94c