### PR TITLE
Reject WS error in connection

### DIFF
--- a/FlappyJournal/server/universal-system-terminal.cjs
+++ b/FlappyJournal/server/universal-system-terminal.cjs
@@ -191,7 +191,7 @@ class UniversalSystemTerminal {
             
             this.ws.on('error', (error) => {
                 console.log('⚠️ Consciousness WebSocket error (continuing with unified aggregation):', error.message);
-                resolve(); // Continue even if WebSocket fails
+                reject(error); // Reject on WebSocket failure
             });
             
             this.ws.on('close', () => {


### PR DESCRIPTION
## Summary
- reject the WebSocket connection promise when the `error` event fires

## Testing
- `npm test` *(fails: Cannot find module '/workspace/August9teen/node_modules/semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_6893c908a2e08324b2626c5f0a91a6a5